### PR TITLE
Rebrand Iodine links to Fileglass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # New-Phone-Who-Dis (NPWD)
 
-<img src="https://beta.iodine.gg/zVkK7.png" width="500" height="300" />
+<img src="https://i.file.glass/zVkK7.png" width="500" height="300" />
 
 
 NPWD is our flagship and current running project. The team has been working on the project since August, 2020. This resource isn’t complete yet and currently has a pre-release. There is however no ETA for a stable release, yet. Feel free to test it out in a dev environment by following the installation guide.
@@ -36,13 +36,13 @@ We do not want issues opened that are due to the phone being **WIP** as this slo
 
 Most of these apps have UI that does **not** represent the final product and are subject to change.
 
-- [**Bank**](https://beta.iodine.gg/Eh53X.png)
-- [**Calculator**](https://beta.iodine.gg/s6VQV.png)
-- [**Camera**](https://beta.iodine.gg/vW0y9.png)
-- [**Contacts**](https://beta.iodine.gg/3fujR.png)
-- [**Marketplace**](https://beta.iodine.gg/5bUa8.png)
-- [**Messages**](https://beta.iodine.gg/S4Lia.png)
-- [**Notes**](https://beta.iodine.gg/qTkBb.png)
-- [**Phone**](https://beta.iodine.gg/z0ii9.png)
-- [**Settings**](https://beta.iodine.gg/mZAIt.png)
-- [**Twitter**](https://beta.iodine.gg/rQZFR.png)
+- [**Bank**](https://i.file.glass/Eh53X.png)
+- [**Calculator**](https://i.file.glass/s6VQV.png)
+- [**Camera**](https://i.file.glass/vW0y9.png)
+- [**Contacts**](https://i.file.glass/3fujR.png)
+- [**Marketplace**](https://i.file.glass/5bUa8.png)
+- [**Messages**](https://i.file.glass/S4Lia.png)
+- [**Notes**](https://i.file.glass/qTkBb.png)
+- [**Phone**](https://i.file.glass/z0ii9.png)
+- [**Settings**](https://i.file.glass/mZAIt.png)
+- [**Twitter**](https://i.file.glass/rQZFR.png)

--- a/import.sql
+++ b/import.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS `npwd_twitter_profiles` (
   `profile_name` varchar(90) NOT NULL,
   `identifier` varchar(48) NOT NULL,
 #   Default Profile avatar can be set here
-  `avatar_url` varchar(255) DEFAULT 'https://beta.iodine.gg/QrEvq.png',
+  `avatar_url` varchar(255) DEFAULT 'https://i.file.glass/QrEvq.png',
   `bio` varchar(512) DEFAULT NULL,
   `location` varchar(45) DEFAULT NULL,
   `job` varchar(45) DEFAULT NULL,

--- a/phone/src/apps/camera/components/CameraApp.tsx
+++ b/phone/src/apps/camera/components/CameraApp.tsx
@@ -14,11 +14,11 @@ InjectDebugData([
     data: [
       {
         id: 1,
-        image: 'https://beta.iodine.gg/noDcb.jpeg',
+        image: 'https://i.file.glass/noDcb.jpeg',
       },
       {
         id: 2,
-        image: 'https://beta.iodine.gg/teUcY.jpeg',
+        image: 'https://i.file.glass/teUcY.jpeg',
       },
     ],
   },

--- a/phone/src/apps/marketplace/hooks/state.ts
+++ b/phone/src/apps/marketplace/hooks/state.ts
@@ -13,7 +13,7 @@ const defaultData: MarketplaceListing[] = [
     title: 'eeeeeeeeeeeeeeeeeeeeeeeee',
     description:
       'skldfsdEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE',
-    url: 'https://beta.iodine.gg/706Y3.jpeg',
+    url: 'https://i.file.glass/706Y3.jpeg',
   },
   {
     id: 2,

--- a/phone/src/os/debug/InjectDebugData.ts
+++ b/phone/src/os/debug/InjectDebugData.ts
@@ -17,11 +17,11 @@ interface DebugEvent<P = any> {
  *   data: [
  *    {
  *      id: 1,
- *      image: 'https://beta.iodine.gg/noDcb.jpeg',
+ *      image: 'https://i.file.glass/noDcb.jpeg',
  *    },
  *    {
  *      id: 2,
- *      image: 'https://beta.iodine.gg/noDcb.jpeg',
+ *      image: 'https://i.file.glass/noDcb.jpeg',
  *    }
  *   ]
  *  }


### PR DESCRIPTION
Iodine (iodine.gg) has rebranded to Fileglass (file.glass). Whilst the current Iodine links still work, they add extra, unnecessary overhead having to redirect from Iodine.