### PR TITLE
Fix String parameter on getLocationFromUrl in order to be able to build.

### DIFF
--- a/phone/src/common/utils/getLocationFromUrl.ts
+++ b/phone/src/common/utils/getLocationFromUrl.ts
@@ -1,6 +1,6 @@
 import parseUrl from 'parse-url';
 
-export const getLocationFromUrl = (url: String) => {
+export const getLocationFromUrl = (url: string) => {
   const { pathname, search } = parseUrl(url);
   const searchStr = '?' + (search || '');
   return { pathname, search: searchStr };


### PR DESCRIPTION
Error Argument of type 'String' is not assignable to parameter of type 'string'.
  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.

Fix