### PR TITLE
feat(config): Add the ability to change used identifier type

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
     "useIdentifierPrefix": false,
     "playerTable": "users",
     "identifierColumn": "identifier",
+    "identifierType": "license",
     "profileQueries": true,
     "phoneNumberColumn": "phone_number"
   },

--- a/resources/server/utils/getPlayerGameLicense.ts
+++ b/resources/server/utils/getPlayerGameLicense.ts
@@ -7,7 +7,7 @@ export const getPlayerGameLicense = (src: number): null | string => {
 
   let playerIdentifier;
   for (const identifier of playerIdentifiers) {
-    if (identifier.includes('license:')) {
+    if (identifier.includes(config.database.identifierType + ':')) {
       if (config.database.useIdentifierPrefix) playerIdentifier = identifier;
       else playerIdentifier = identifier.split(':')[1];
     }

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -40,6 +40,7 @@ interface BankConfig {
 interface DatabaseConfig {
   playerTable: string;
   identifierColumn: string;
+  identifierType: string;
   useIdentifierPrefix: boolean;
   profileQueries: boolean;
   phoneNumberColumn: string;


### PR DESCRIPTION
Hi,

This PR is now done from the develop branch as requested by itschip.

**Reposting old info :**
My server is currently using discord identifier to register users, and many other servers will be using steam ids.
So i'm suggesting make "license:" configurable for anyone would be a good idea.

Changing it from "license" to "discord" will not lead to any other issue from my testing as all identifier are string type even if they only contains number.