### PR TITLE
feat(client/photo): add the ability to use a custom image server

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,6 +17,17 @@
     "profileQueries": true,
     "phoneNumberColumn": "phone_number"
   },
+  "images": {
+    "url": "https://api.imgur.com/3/image",
+    "type": "imgur",
+    "imageEncoding": "jpg",
+    "contentType": "multipart/form-data",
+    "authorizationPrefix": "Client-ID",
+    "useAuthorization": true,
+    "returnedUrlObjectName": "data",
+    "returnedUrlFieldName": "link",
+    "returnedUrlInArray": false
+  },
   "twitter": {
     "showNotifications": true,
     "generateProfileNameFromUsers": true,

--- a/resources/client/cl_photo.ts
+++ b/resources/client/cl_photo.ts
@@ -2,7 +2,7 @@ import { PhotoEvents } from '../../typings/photo';
 import { Delay } from '../utils/fivem';
 import { sendCameraEvent, sendMessage } from '../utils/messages';
 import { PhoneEvents } from '../../typings/phone';
-import { ClUtils } from './client';
+import { ClUtils, config } from './client';
 import { animationService } from './animations/animation.controller';
 import { RegisterNuiCB, RegisterNuiProxy } from './cl_utils';
 
@@ -104,21 +104,23 @@ const handleCameraExit = async () => {
 const takePhoto = () =>
   new Promise((res, rej) => {
     // Return and log error if screenshot basic token not found
-    if (SCREENSHOT_BASIC_TOKEN === 'none') {
+    if (SCREENSHOT_BASIC_TOKEN === 'none' && config.images.useAuthorization) {
       return console.error('Screenshot basic token not found. Please set in server.cfg');
     }
     exp['screenshot-basic'].requestScreenshotUpload(
-      'https://api.imgur.com/3/image',
-      'imgur',
+      config.images.url,
+      config.images.type,
       {
+        encoding: config.images.imageEncoding,
         headers: {
-          authorization: `Client-ID ${SCREENSHOT_BASIC_TOKEN}`,
-          'content-type': 'multipart/form-data',
+          authorization: config.images.useAuthorization ? `${config.images.authorizationPrefix} ${SCREENSHOT_BASIC_TOKEN}` : undefined,
+          'content-type': config.images.contentType,
         },
       },
       async (data: any) => {
         try {
-          const imageLink = JSON.parse(data).data.link;
+          const parsedData = JSON.parse(data);
+          const imageLink = config.images.returnedUrlInArray ? parsedData[config.images.returnedUrlObjectName][0][config.images.returnedUrlFieldName] : parsedData[config.images.returnedUrlObjectName][config.images.returnedUrlFieldName];
           const resp = await ClUtils.emitNetPromise(PhotoEvents.UPLOAD_PHOTO, imageLink);
           console.log('export shit', resp);
           res(resp);

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -46,6 +46,18 @@ interface DatabaseConfig {
   phoneNumberColumn: string;
 }
 
+interface ImageConfig {
+  url: string;
+  type: string;
+  imageEncoding: 'png' | 'jpg' | 'webp';
+  contentType: string;
+  authorizationPrefix: string;
+  useAuthorization: boolean;
+  returnedUrlObjectName: string;
+  returnedUrlFieldName: string;
+  returnedUrlInArray: boolean;
+}
+
 interface PhoneAsItemConfig {
   enabled: boolean;
   exportResource: string;
@@ -63,4 +75,5 @@ export interface ResourceConfig {
   notificationPosition: NotificationConfig;
   general: General;
   debug: Debug;
+  images: ImageConfig;
 }


### PR DESCRIPTION
Credits to AvarianKnight for the base of this commit from [PR 256](https://github.com/project-error/npwd/pull/256)

This will allow changing upload url, field type for screenshot-basic (imgur or files[] for example)

Custom imageEncoding (Not sure why Avarian changed it to jpg by default as this is also the default in screenshot-basic as of this line : https://github.com/citizenfx/screenshot-basic/blob/0712d9ed5a0c6899db9bab37cd94f03310bb416c/src/client/client.ts#L51)

About returnedUrl**
Depending on the host, this could vary a lot, as we can't specify them all, I adopted the most known one
Imgur return a json with "data" object containing "link" as a field of this object.
Avarian selected host (we don't know the name) return a json with "files" array, the first object of this array containing the "url" field.
Discord webhooks also agree to this format, but is naming their array "attachments", the first obj of this array containing "proxy_url" field.

I think this variation can allow be agreed upon with this type of configuration.
There could about be variation in the authorization prefix so I made it configurable. (Bearer or API-ID are known prefix)

This is a long commit, with a lot a configurability in it, so it will probably need some testing before merging.