### PR TITLE
fix: Add dependency into manifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,3 +19,7 @@ files {
     'resources/html/index.html',
     'resources/html/**/*',
 }
+
+dependency {
+	'screenshot-basic'
+}


### PR DESCRIPTION
screenshot-basic is required for camera functionality so its a dependency and should be listed as such imo. I don't really see it being an optional thing since photos are going to be integrated into messages and at some point I think marketplace if I'm not mistaken.