### PR TITLE
fix(config): Mismatch between config definition

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "PhoneAsItem": {
     "enabled": false,
     "exportResource": "my-core-resource",
-    "exportName": "myCheckerFunction"
+    "exportFunction": "myCheckerFunction"
   },
   "general": {
     "useDashNumber": true,


### PR DESCRIPTION
Hi, seems like the config.json doesn't match with config definition in PhoneAsItemConfig
PhoneAsItemConfig has this argument named exportFunction but config.json contains exportName

Just fixing this quickly 👍