### PR TITLE
fix(phone/tooltips): don't display tooltips when phone is hidden

### DIFF
--- a/phone/src/apps/marketplace/components/MarketplaceList/ListingActions.tsx
+++ b/phone/src/apps/marketplace/components/MarketplaceList/ListingActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Tooltip, Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
@@ -14,6 +14,7 @@ import { useSnackbar } from '../../../../ui/hooks/useSnackbar';
 import { ServerPromiseResp } from '../../../../../../typings/common';
 import { useMyPhoneNumber } from '../../../../os/simcard/hooks/useMyPhoneNumber';
 import { useCall } from '../../../../os/call/hooks/useCall';
+import { Tooltip } from '../../../../ui/components/Tooltip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {

--- a/phone/src/apps/match/components/ActiveProfile.tsx
+++ b/phone/src/apps/match/components/ActiveProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Card, Fab, Box, Tooltip } from '@mui/material';
+import { Card, Fab, Box } from '@mui/material';
 import CancelIcon from '@mui/icons-material/Clear';
 import FireIcon from '@mui/icons-material/Whatshot';
 import makeStyles from '@mui/styles/makeStyles';
@@ -9,6 +9,7 @@ import { FormattedProfile } from '../../../../../typings/match';
 import Draggable from './Draggable';
 import StatusDisplay from './StatusDisplay';
 import Profile from './profile/Profile';
+import { Tooltip } from '../../../ui/components/Tooltip';
 
 const useStyles = makeStyles({
   root: {

--- a/phone/src/apps/settings/components/SettingItem.tsx
+++ b/phone/src/apps/settings/components/SettingItem.tsx
@@ -7,10 +7,10 @@ import {
   Box,
   Slider,
   IconButton,
-  Tooltip,
   Typography,
   Switch,
 } from '@mui/material';
+import { Tooltip } from '../../../ui/components/Tooltip';
 
 interface ISettingItem {
   options?: any;

--- a/phone/src/ui/components/AppIcon.tsx
+++ b/phone/src/ui/components/AppIcon.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { darken, Theme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import { green } from '@mui/material/colors';
-import { Avatar, Badge, Button, Tooltip, Zoom } from '@mui/material';
+import { Avatar, Badge, Button, Zoom } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { INotificationIcon } from '../../os/notifications/providers/NotificationsProvider';
+import { Tooltip } from './Tooltip';
 
 const useStyles = makeStyles<Theme, { color: string; backgroundColor: string }>((theme) => ({
   root: {

--- a/phone/src/ui/components/Tooltip.tsx
+++ b/phone/src/ui/components/Tooltip.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { TooltipProps } from '@mui/material';
+import { useRecoilValue } from 'recoil';
+import { phoneState } from '../../os/phone/hooks/state';
+
+export const Tooltip: React.FC<TooltipProps> = ({ children, ...props }) => {
+  const phoneVisible = useRecoilValue(phoneState.visibility);
+
+  return (
+    <Tooltip {...props} open={!phoneVisible ? false : undefined}>
+      {children}
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
This should work to resolve #326, but I haven't been able to test this yet. If anybody gets around to testing this before me, feel free to merge.