### PR TITLE
fix: Multicharacter loading and number generation

### DIFF
--- a/resources/client/cl_main.ts
+++ b/resources/client/cl_main.ts
@@ -180,3 +180,25 @@ RegisterNuiCB<{ keepGameFocus: boolean }>(
 //   const time = getCurrentGameTime()
 //   sendMessage('PHONE', 'setTime', time)
 // }, 2000);
+
+// Set a global function to check if the player is loaded
+let playerLoaded = false;
+(global as any).playerReady = async () => {
+  if (playerLoaded) return true;
+  return new Promise<boolean>((resolve) => {
+    setInterval(() => {
+      if (playerLoaded) resolve(true);
+    }, 50);
+  });
+};
+
+// Register events to set the state of playerLoaded
+if (!config.general.enableMultiChar) {
+  on(`playerSpawned`, async () => {
+    playerLoaded = true;
+  });
+} else {
+  onNet(PhoneEvents.PLAYER_LOADED, async (state: boolean) => {
+    playerLoaded = state;
+  });
+}

--- a/resources/client/cl_utils.ts
+++ b/resources/client/cl_utils.ts
@@ -1,3 +1,4 @@
+import { PhoneEvents } from '../../typings/phone';
 import { uuidv4 } from '../utils/fivem';
 import { ClUtils, config } from './client';
 
@@ -76,13 +77,13 @@ const playerReady = async () => {
   });
 };
 
-setTimeout(async () => {
+setTimeout(() => {
   if (!config.general.enableMultiChar) {
     on(`playerSpawned`, async () => {
       playerLoaded = true;
     });
   } else {
-    onNet(`npwd:playerLoaded`, async (state: boolean) => {
+    onNet(PhoneEvents.PLAYER_LOADED, async (state: boolean) => {
       playerLoaded = state;
     });
   }

--- a/resources/client/cl_utils.ts
+++ b/resources/client/cl_utils.ts
@@ -1,6 +1,5 @@
-import { PhoneEvents } from '../../typings/phone';
 import { uuidv4 } from '../utils/fivem';
-import { ClUtils, config } from './client';
+import { ClUtils } from './client';
 
 interface ISettings {
   promiseTimeout: number;
@@ -66,29 +65,6 @@ export const RegisterNuiCB = <T = any>(event: string, callback: CallbackFn<T>) =
   on(`__cfx_nui:${event}`, callback);
 };
 
-// Utilise this function alongside NuiProxy to prevent eager mounting (maybe)
-let playerLoaded = false;
-const playerReady = async () => {
-  if (playerLoaded) return true;
-  return new Promise<boolean>((resolve) => {
-    setInterval(() => {
-      if (playerLoaded) resolve(true);
-    }, 50);
-  });
-};
-
-setTimeout(() => {
-  if (!config.general.enableMultiChar) {
-    on(`playerSpawned`, async () => {
-      playerLoaded = true;
-    });
-  } else {
-    onNet(PhoneEvents.PLAYER_LOADED, async (state: boolean) => {
-      playerLoaded = state;
-    });
-  }
-}, 0);
-
 /**
  *  Will Register an NUI event listener that will immediately
  *  proxy to a server side event of the same name and wait
@@ -98,7 +74,7 @@ setTimeout(() => {
 export const RegisterNuiProxy = (event: string) => {
   RegisterNuiCallbackType(event);
   on(`__cfx_nui:${event}`, async (data: unknown, cb: Function) => {
-    await playerReady();
+    await (global as any).playerReady();
     try {
       const res = await ClUtils.emitNetPromise(event, data);
       cb(res);

--- a/resources/server/misc/functions.ts
+++ b/resources/server/misc/functions.ts
@@ -8,13 +8,13 @@ export async function findOrGeneratePhoneNumber(identifier: string): Promise<str
 
   const castRes = res as Record<string, unknown>[];
 
-  if (res) return castRes[0][config.database.phoneNumberColumn] as string;
+  if (castRes && castRes[0][config.database.phoneNumberColumn] !== null) return castRes[0][config.database.phoneNumberColumn] as string;
 
-  const gennedNumber = generateUniquePhoneNumber();
+  const gennedNumber = await generateUniquePhoneNumber();
 
   const updateQuery = `UPDATE ${config.database.playerTable} SET ${config.database.phoneNumberColumn} = ? WHERE ${config.database.identifierColumn} = ?`;
   // Update profile with new generated number
-  await DbInterface.exec(updateQuery, [gennedNumber, identifier]);
+  await DbInterface._rawExec(updateQuery, [gennedNumber, identifier]);
 
   return gennedNumber;
 }

--- a/resources/server/players/player.controller.ts
+++ b/resources/server/players/player.controller.ts
@@ -73,6 +73,7 @@ if (config.general.enableMultiChar) {
     playerLogger.debug('Receive newPlayer event, data:');
     playerLogger.debug(playerDTO);
     await PlayerService.handleNewPlayerEvent(playerDTO);
+    emitNet(`npwd:playerLoaded`, playerDTO.source, true)
   });
 
   on('npwd:unloadPlayer', (src: number) => {
@@ -81,5 +82,6 @@ if (config.general.enableMultiChar) {
     }
     playerLogger.debug(`Received unloadPlayer event for ${src}`);
     PlayerService.handleUnloadPlayerEvent(src);
+    emitNet(`npwd:playerLoaded`, src, false)
   });
 }

--- a/resources/server/players/player.controller.ts
+++ b/resources/server/players/player.controller.ts
@@ -73,7 +73,7 @@ if (config.general.enableMultiChar) {
     playerLogger.debug('Receive newPlayer event, data:');
     playerLogger.debug(playerDTO);
     await PlayerService.handleNewPlayerEvent(playerDTO);
-    emitNet(`npwd:playerLoaded`, playerDTO.source, true)
+    emitNet(PhoneEvents.PLAYER_LOADED, playerDTO.source, true)
   });
 
   on('npwd:unloadPlayer', (src: number) => {
@@ -82,6 +82,6 @@ if (config.general.enableMultiChar) {
     }
     playerLogger.debug(`Received unloadPlayer event for ${src}`);
     PlayerService.handleUnloadPlayerEvent(src);
-    emitNet(`npwd:playerLoaded`, src, false)
+    emitNet(PhoneEvents.PLAYER_LOADED, src, false)
   });
 }

--- a/resources/server/players/player.interfaces.ts
+++ b/resources/server/players/player.interfaces.ts
@@ -1,6 +1,7 @@
 export interface PlayerAddData {
   source: number;
   identifier: string;
+  phoneNumber?: string;
   firstname?: string;
   lastname?: string;
 }

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -165,11 +165,10 @@ class _PlayerService {
    *
    */
   async handleNewPlayerEvent({ source: src, identifier, phoneNumber, firstname, lastname }: PlayerAddData) {
-    const player = await this.createNewPlayer({ src, identifier: identifier.toString() });
+    const player = await this.createNewPlayer({ src, identifier: identifier.toString(), phoneNumber });
 
     if (firstname) player.setFirstName(firstname);
     if (lastname) player.setLastName(lastname);
-    if (phoneNumber) player.setPhoneNumber(phoneNumber);
 
     this.addPlayerToMaps(src, player);
 

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -137,15 +137,18 @@ class _PlayerService {
   async createNewPlayer({
     src,
     identifier,
+    phoneNumber
   }: {
     src: number;
     identifier: string;
+    phoneNumber: string;
   }): Promise<Player | null> {
     const username = GetPlayerName(src.toString());
 
-    const phoneNumber = await findOrGeneratePhoneNumber(identifier);
-
-    if (!phoneNumber) return null;
+    if (!phoneNumber) {
+      phoneNumber = await findOrGeneratePhoneNumber(identifier);
+      if (!phoneNumber) return null;
+    }
 
     return new Player({
       source: src,

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -161,11 +161,12 @@ class _PlayerService {
    * @param NewPlayerDTO - A DTO with all the new info required to instantiate a new player
    *
    */
-  async handleNewPlayerEvent({ source: src, identifier, firstname, lastname }: PlayerAddData) {
+  async handleNewPlayerEvent({ source: src, identifier, phoneNumber, firstname, lastname }: PlayerAddData) {
     const player = await this.createNewPlayer({ src, identifier: identifier.toString() });
 
     if (firstname) player.setFirstName(firstname);
     if (lastname) player.setLastName(lastname);
+    if (phoneNumber) player.setPhoneNumber(phoneNumber);
 
     this.addPlayerToMaps(src, player);
 

--- a/typings/phone.ts
+++ b/typings/phone.ts
@@ -13,6 +13,7 @@ export enum PhoneEvents {
   FETCH_CREDENTIALS = 'npwd:getCredentials',
   ON_INIT = 'npwd:onInit',
   TOGGLE_KEYS = 'npwd:toggleAllControls',
+  PLAYER_LOADED = 'npwd:playerLoaded',
 }
 
 // Used to standardize the server response


### PR DESCRIPTION
An event is triggered on the client after the player is added or removed, updating the `playerLoaded` value.
Default state of playerLoaded is false and, if not using multichar, will be changed by the playerSpawned event; not sure if it's necessary (not sure if #330 applies to regular spawning).

I'm not sure how `generateUniquePhoneNumber()` worked at all, but apparently it does for non-multichar? Didn't await result and just ended up querying with a promise as the first parameter; regardless, I needed to use rawExec to successfully query the database or I would get some error related to an undefined value and reading 'pool'. 😕


Refactor and improve this however since it could 100% be done cleaner and I'm not sure where you would want the playerReady function defined.