### PR TITLE
Fix: contact querry based only off idenitfier

### DIFF
--- a/import.sql
+++ b/import.sql
@@ -4,11 +4,12 @@
 
 CREATE TABLE IF NOT EXISTS `npwd_phone_contacts`
 (
-    `id`         int(11)      NOT NULL AUTO_INCREMENT,
-    `identifier` varchar(48)           DEFAULT NULL,
-    `avatar`     varchar(512)          DEFAULT NULL,
-    `number`     varchar(20)           DEFAULT NULL,
-    `display`    varchar(255) NOT NULL DEFAULT '',
+    `id`                int(11)         NOT NULL AUTO_INCREMENT,
+    `identifier`        varchar(48)     DEFAULT NULL,
+    `user_number`       varchar(20)     DEFAULT NULL,
+    `number`            varchar(20)     DEFAULT NULL,
+    `display`           varchar(255)    NOT NULL DEFAULT '',
+    `avatar`            varchar(512)    DEFAULT NULL,
     PRIMARY KEY (id)
 );
 

--- a/resources/server/contacts/contacts.db.ts
+++ b/resources/server/contacts/contacts.db.ts
@@ -3,21 +3,27 @@ import { ResultSetHeader } from 'mysql2';
 import DbInterface from '../db/db_wrapper';
 
 export class _ContactsDB {
-  async fetchAllContacts(identifier: string): Promise<Contact[]> {
-    const query = 'SELECT * FROM npwd_phone_contacts WHERE identifier = ? ORDER BY display ASC';
-    const [results] = await DbInterface._rawExec(query, [identifier]);
+  async fetchAllContacts(identifier: string, phoneNumber: string): Promise<Contact[]> {
+    const query =
+      'SELECT * FROM npwd_phone_contacts WHERE identifier = ? AND user_number = ? ORDER BY display ASC';
+    const [results] = await DbInterface._rawExec(query, [identifier, phoneNumber]);
     return <Contact[]>results;
   }
 
   async addContact(
     identifier: string,
+    user_number: string,
     { display, avatar, number }: PreDBContact,
   ): Promise<Contact> {
     const query =
-      'INSERT INTO npwd_phone_contacts (identifier, number, display, avatar) VALUES (?, ?, ?, ?)';
-
-    const [setResult] = await DbInterface._rawExec(query, [identifier, number, display, avatar]);
-
+      'INSERT INTO npwd_phone_contacts (identifier, user_number, number, display, avatar) VALUES (?, ?, ?, ?, ?)';
+    const [setResult] = await DbInterface._rawExec(query, [
+      identifier,
+      user_number,
+      number,
+      display,
+      avatar,
+    ]);
     return {
       id: (<ResultSetHeader>setResult).insertId,
       number,
@@ -26,21 +32,23 @@ export class _ContactsDB {
     };
   }
 
-  async updateContact(contact: Contact, identifier: string): Promise<any> {
+  async updateContact(contact: Contact, identifier: string, phoneNumber: string): Promise<any> {
     const query =
-      'UPDATE npwd_phone_contacts SET number = ?, display = ?, avatar = ? WHERE id = ? AND identifier = ?';
+      'UPDATE npwd_phone_contacts SET number = ?, display = ?, avatar = ? WHERE id = ? AND identifier = ? AND user_number = ?';
     await DbInterface._rawExec(query, [
       contact.number,
       contact.display,
       contact.avatar,
       contact.id,
       identifier,
+      phoneNumber,
     ]);
   }
 
-  async deleteContact(contactId: number, identifier: string): Promise<void> {
-    const query = 'DELETE FROM npwd_phone_contacts WHERE id = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [contactId, identifier]);
+  async deleteContact(contactId: number, identifier: string, phoneNumber: string): Promise<void> {
+    const query =
+      'DELETE FROM npwd_phone_contacts WHERE id = ? AND identifier = ? AND user_number = ?';
+    await DbInterface._rawExec(query, [contactId, identifier, phoneNumber]);
   }
 }
 

--- a/resources/server/contacts/contacts.service.ts
+++ b/resources/server/contacts/contacts.service.ts
@@ -17,8 +17,9 @@ class _ContactService {
     resp: PromiseEventResp<void>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
+    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
     try {
-      await this.contactsDB.updateContact(reqObj.data, identifier);
+      await this.contactsDB.updateContact(reqObj.data, identifier, srcPlayerNumber);
       resp({ status: 'ok' });
     } catch (e) {
       contactsLogger.error(`Error in handleUpdateContact (${identifier}), ${e.message}`);
@@ -30,8 +31,9 @@ class _ContactService {
     resp: PromiseEventResp<void>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
+    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
     try {
-      await this.contactsDB.deleteContact(reqObj.data.id, identifier);
+      await this.contactsDB.deleteContact(reqObj.data.id, identifier, srcPlayerNumber);
       resp({ status: 'ok' });
     } catch (e) {
       resp({ status: 'error', errorMsg: 'DB_ERROR' });
@@ -43,8 +45,9 @@ class _ContactService {
     resp: PromiseEventResp<Contact>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
+    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
     try {
-      const contact = await this.contactsDB.addContact(identifier, reqObj.data);
+      const contact = await this.contactsDB.addContact(identifier, srcPlayerNumber, reqObj.data);
 
       resp({ status: 'ok', data: contact });
     } catch (e) {
@@ -57,8 +60,10 @@ class _ContactService {
     resp: PromiseEventResp<Contact[]>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
+    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
+    console.log(srcPlayerNumber);
     try {
-      const contacts = await this.contactsDB.fetchAllContacts(identifier);
+      const contacts = await this.contactsDB.fetchAllContacts(identifier, srcPlayerNumber);
       resp({ status: 'ok', data: contacts });
     } catch (e) {
       resp({ status: 'error', errorMsg: 'DB_ERROR' });

--- a/resources/server/contacts/contacts.service.ts
+++ b/resources/server/contacts/contacts.service.ts
@@ -61,7 +61,6 @@ class _ContactService {
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
     const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
-    console.log(srcPlayerNumber);
     try {
       const contacts = await this.contactsDB.fetchAllContacts(identifier, srcPlayerNumber);
       resp({ status: 'ok', data: contacts });

--- a/resources/server/contacts/contacts.service.ts
+++ b/resources/server/contacts/contacts.service.ts
@@ -17,7 +17,8 @@ class _ContactService {
     resp: PromiseEventResp<void>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
-    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
+    const player = PlayerService.getPlayer(reqObj.source);
+    const srcPlayerNumber = player.getPhoneNumber();
     try {
       await this.contactsDB.updateContact(reqObj.data, identifier, srcPlayerNumber);
       resp({ status: 'ok' });
@@ -31,7 +32,8 @@ class _ContactService {
     resp: PromiseEventResp<void>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
-    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
+    const player = PlayerService.getPlayer(reqObj.source);
+    const srcPlayerNumber = player.getPhoneNumber();
     try {
       await this.contactsDB.deleteContact(reqObj.data.id, identifier, srcPlayerNumber);
       resp({ status: 'ok' });
@@ -45,7 +47,8 @@ class _ContactService {
     resp: PromiseEventResp<Contact>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
-    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
+    const player = PlayerService.getPlayer(reqObj.source);
+    const srcPlayerNumber = player.getPhoneNumber();
     try {
       const contact = await this.contactsDB.addContact(identifier, srcPlayerNumber, reqObj.data);
 
@@ -60,7 +63,8 @@ class _ContactService {
     resp: PromiseEventResp<Contact[]>,
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
-    const srcPlayerNumber = PlayerService.getPhoneNumber(reqObj.source);
+    const player = PlayerService.getPlayer(reqObj.source);
+    const srcPlayerNumber = player.getPhoneNumber();
     try {
       const contacts = await this.contactsDB.fetchAllContacts(identifier, srcPlayerNumber);
       resp({ status: 'ok', data: contacts });

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -58,14 +58,6 @@ class _PlayerService {
   }
 
   /**
-   * Returns the player phone number for a given source
-   * Will return null if no player is found online with that source
-   **/
-  getPhoneNumber(source: number): string {
-    return this.getPlayer(source).getPhoneNumber();
-  }
-
-  /**
    * Returns the player phoneNumber for a passed identifier
    * @param identifier The players phone number
    */

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -58,6 +58,14 @@ class _PlayerService {
   }
 
   /**
+   * Returns the player phone number for a given source
+   * Will return null if no player is found online with that source
+   **/
+  getPhoneNumber(source: number): string {
+    return this.getPlayer(source).getPhoneNumber();
+  }
+
+  /**
    * Returns the player phoneNumber for a passed identifier
    * @param identifier The players phone number
    */
@@ -138,7 +146,7 @@ class _PlayerService {
   async createNewPlayer({
     src,
     identifier,
-    phoneNumber
+    phoneNumber,
   }: {
     src: number;
     identifier: string;
@@ -165,8 +173,18 @@ class _PlayerService {
    * @param NewPlayerDTO - A DTO with all the new info required to instantiate a new player
    *
    */
-  async handleNewPlayerEvent({ source: src, identifier, phoneNumber, firstname, lastname }: PlayerAddData) {
-    const player = await this.createNewPlayer({ src, identifier: identifier.toString(), phoneNumber });
+  async handleNewPlayerEvent({
+    source: src,
+    identifier,
+    phoneNumber,
+    firstname,
+    lastname,
+  }: PlayerAddData) {
+    const player = await this.createNewPlayer({
+      src,
+      identifier: identifier.toString(),
+      phoneNumber,
+    });
 
     if (firstname) player.setFirstName(firstname);
     if (lastname) player.setLastName(lastname);


### PR DESCRIPTION
Resolves https://github.com/project-error/npwd/issues/336

 `number` within the sql should probably be changed to `contact_number` but this would mean some additional changes to accommodate this. Like adjusting [this](https://github.com/project-error/npwd/blob/a33f244a547559db7363d7388b1a05ad4cadbc02/resources/server/messages/messages.db.ts#L47) querry within messages and some other references. 
 
 Outside my expertise so I left it as number 🤷🏻.
 
 Edit: Theres also the issue of the code style within `contacts.services.ts` being non uniform so it's a bit weird at first. It needs some refactoring as well.