### PR TITLE
refactor: remove calls to DbInterface._rawExec

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -17,7 +17,6 @@
     "@discordjs/collection": "^0.2.4",
     "@project-error/pe-utils": "^0.1.6",
     "axios": "^0.21.4",
-    "connection-string-parser": "^1.0.4",
     "dayjs": "^1.10.7",
     "fivem-js": "^1.3.1",
     "md5": "^2.3.0",

--- a/resources/server/calls/calls.db.ts
+++ b/resources/server/calls/calls.db.ts
@@ -6,17 +6,12 @@ export class CallsRepo {
   async saveCall(call: CallHistoryItem): Promise<void> {
     const query =
       'INSERT INTO npwd_calls (identifier, transmitter, receiver, `start`) VALUES (?, ?, ?, ?)';
-    await DbInterface._rawExec(query, [
-      call.identifier,
-      call.transmitter,
-      call.receiver,
-      call.start,
-    ]);
+    await DbInterface.insert(query, [call.identifier, call.transmitter, call.receiver, call.start]);
   }
 
   async updateCall(call: CallHistoryItem, isAccepted: boolean, end: number): Promise<void> {
     const query = 'UPDATE npwd_calls SET is_accepted=?, end=? WHERE identifier = ?';
-    await DbInterface._rawExec(query, [isAccepted, end, call.identifier]);
+    await DbInterface.exec(query, [isAccepted, end, call.identifier]);
   }
 
   async fetchCalls(
@@ -25,7 +20,7 @@ export class CallsRepo {
   ): Promise<CallHistoryItem[]> {
     const query =
       'SELECT * FROM npwd_calls WHERE receiver = ? OR transmitter = ? ORDER BY id DESC LIMIT ?';
-    const [result] = await DbInterface._rawExec(query, [phoneNumber, phoneNumber, limit]);
+    const result = await DbInterface.fetch(query, [phoneNumber, phoneNumber, limit]);
 
     return <CallHistoryItem[]>result;
   }

--- a/resources/server/contacts/contacts.db.ts
+++ b/resources/server/contacts/contacts.db.ts
@@ -1,11 +1,10 @@
 import { Contact, PreDBContact } from '../../../typings/contact';
-import { ResultSetHeader } from 'mysql2';
 import DbInterface from '../db/db_wrapper';
 
 export class _ContactsDB {
   async fetchAllContacts(identifier: string): Promise<Contact[]> {
     const query = 'SELECT * FROM npwd_phone_contacts WHERE identifier = ? ORDER BY display ASC';
-    const [results] = await DbInterface._rawExec(query, [identifier]);
+    const results = await DbInterface.fetch(query, [identifier]);
     return <Contact[]>results;
   }
 
@@ -16,10 +15,10 @@ export class _ContactsDB {
     const query =
       'INSERT INTO npwd_phone_contacts (identifier, number, display, avatar) VALUES (?, ?, ?, ?)';
 
-    const [setResult] = await DbInterface._rawExec(query, [identifier, number, display, avatar]);
+    const insertId = await DbInterface.insert(query, [identifier, number, display, avatar]);
 
     return {
-      id: (<ResultSetHeader>setResult).insertId,
+      id: insertId,
       number,
       avatar,
       display,
@@ -29,7 +28,7 @@ export class _ContactsDB {
   async updateContact(contact: Contact, identifier: string): Promise<any> {
     const query =
       'UPDATE npwd_phone_contacts SET number = ?, display = ?, avatar = ? WHERE id = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [
+    await DbInterface.exec(query, [
       contact.number,
       contact.display,
       contact.avatar,
@@ -40,7 +39,7 @@ export class _ContactsDB {
 
   async deleteContact(contactId: number, identifier: string): Promise<void> {
     const query = 'DELETE FROM npwd_phone_contacts WHERE id = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [contactId, identifier]);
+    await DbInterface.exec(query, [contactId, identifier]);
   }
 }
 

--- a/resources/server/db/db_utils.test.ts
+++ b/resources/server/db/db_utils.test.ts
@@ -1,93 +1,13 @@
 import * as db from './db_utils';
 
-const t = 'test value';
-
 describe('parseSemiColonFormat', () => {
-  it('Raises a error with invalid string', () => {
-    expect(() => db.parseSemiColonFormat('no_variables_here')).toThrowError();
-  });
-
   it('Correctly parses configuration options', () => {
-    const test = 'server=127.0.0.1;database=es_extended;userid=user;';
+    const test = 'server=localhost;database=es_extended;userid=user;';
     const result = db.parseSemiColonFormat(test);
 
-    expect(result.server).toEqual('127.0.0.1');
+    expect(result.host).toEqual('localhost');
     expect(result.database).toEqual('es_extended');
-    expect(result.userid).toEqual('user');
+    expect(result.user).toEqual('user');
     expect(result.password).toEqual(undefined);
-  });
-});
-
-describe('getServerHost', () => {
-  it('returns default', () => {
-    expect(db.getServerHost({})).toEqual(db.DEFAULT_HOST);
-  });
-
-  it('Correctly returns host', () => {
-    expect(db.getServerHost({ host: t })).toEqual(t);
-  });
-
-  it('Correctly returns server', () => {
-    expect(db.getServerHost({ server: t })).toEqual(t);
-  });
-
-  it('Correctly returns data source', () => {
-    expect(db.getServerHost({ 'data source': t })).toEqual(t);
-  });
-
-  it('Correctly returns datasource', () => {
-    expect(db.getServerHost({ datasource: t })).toEqual(t);
-  });
-
-  it('Correctly returns addr', () => {
-    expect(db.getServerHost({ addr: t })).toEqual(t);
-  });
-
-  it('Correctly returns address', () => {
-    expect(db.getServerHost({ address: t })).toEqual(t);
-  });
-});
-
-describe('getUserId', () => {
-  it('returns default', () => {
-    expect(db.getUserId({})).toEqual(db.DEFAULT_USER);
-  });
-
-  it('Correctly returns user', () => {
-    expect(db.getUserId({ user: t })).toEqual(t);
-  });
-
-  it('Correctly returns user id', () => {
-    expect(db.getUserId({ 'user id': t })).toEqual(t);
-  });
-
-  it('Correctly returns userid', () => {
-    expect(db.getUserId({ userid: t })).toEqual(t);
-  });
-
-  it('Correctly returns user name', () => {
-    expect(db.getUserId({ 'user name': t })).toEqual(t);
-  });
-
-  it('Correctly returns username', () => {
-    expect(db.getUserId({ username: t })).toEqual(t);
-  });
-
-  it('Correctly returns uid', () => {
-    expect(db.getUserId({ uid: t })).toEqual(t);
-  });
-});
-
-describe('getPassword', () => {
-  // it("returns default", () => {
-  //   expect(() => db.getPassword({})).toThrowError();
-  // });
-
-  it('Correctly returns password', () => {
-    expect(db.getPassword({ password: t })).toEqual(t);
-  });
-
-  it('Correctly returns pwd', () => {
-    expect(db.getPassword({ pwd: t })).toEqual(t);
   });
 });

--- a/resources/server/db/db_wrapper.ts
+++ b/resources/server/db/db_wrapper.ts
@@ -20,8 +20,9 @@ class _DbInterface {
         return result;
       }
 
+      const result = await conn.execute(query, values);
       conn.release();
-      return await pool.execute(query, values);
+      return result;
     } catch (e) {
       this.logger.error(`Error executing ${query} with error message ${e.message}`);
     }

--- a/resources/server/db/pool.ts
+++ b/resources/server/db/pool.ts
@@ -1,13 +1,5 @@
 import mysql from 'mysql2/promise';
-import { ConnectionStringParser } from 'connection-string-parser';
-import {
-  CONNECTION_STRING,
-  DEFAULT_PORT,
-  parseSemiColonFormat,
-  getServerHost,
-  getUserId,
-  getPassword,
-} from './db_utils';
+import { CONNECTION_STRING, connectionOptions, parseSemiColonFormat } from './db_utils';
 import { mainLogger } from '../sv_logger';
 
 // we require set mysql_connection_string  to be set in the config
@@ -30,39 +22,11 @@ if (mysqlConnectionString === 'none') {
  */
 export function generateConnectionPool() {
   try {
-    if (mysqlConnectionString.includes('database=')) {
-      // This is checking for this format:
-      // set mysql_connection_string "server=127.0.0.1;database=es_extended;userid=user;password=pass"
-      const config = parseSemiColonFormat(mysqlConnectionString);
-      return mysql.createPool({
-        host: getServerHost(config),
-        user: getUserId(config),
-        port: config.port ? parseInt(config.port) : DEFAULT_PORT,
-        password: getPassword(config),
-        database: config.database,
-        waitForConnections: true,
-        connectionLimit: 10,
-        queueLimit: 0,
-      });
-    } else {
-      // This is checking for this format:
-      // set mysql_connection_string "mysql://root:pass@127.0.0.1/es_extended?charset=utf8mb4"
-      const connectionStringParser = new ConnectionStringParser({
-        scheme: 'mysql',
-        hosts: [],
-      });
-      const connectionOjbect = connectionStringParser.parse(mysqlConnectionString);
+    const options = mysqlConnectionString.includes('mysql://')
+      ? { uri: mysqlConnectionString }
+      : parseSemiColonFormat(mysqlConnectionString);
 
-      return mysql.createPool({
-        host: connectionOjbect.hosts[0].host,
-        user: connectionOjbect.username,
-        password: connectionOjbect.password,
-        database: connectionOjbect.endpoint,
-        waitForConnections: true,
-        connectionLimit: 10,
-        queueLimit: 0,
-      });
-    }
+    return mysql.createPool(connectionOptions(options));
   } catch (e) {
     mainLogger.error(`SQL Connection Pool Error: ${e.message}`, {
       connection: mysqlConnectionString,
@@ -79,12 +43,12 @@ export async function withTransaction(queries: Promise<any>[]): Promise<any[]> {
   try {
     const results = await Promise.all(queries);
     await connection.commit();
-    await connection.release();
+    connection.release();
     return results;
   } catch (err) {
     mainLogger.warn(`Error when submitting queries in transaction, ${err.message}`);
     await connection.rollback();
-    await connection.release();
+    connection.release();
     return Promise.reject(err);
   }
 }

--- a/resources/server/marketplace/marketplace.db.ts
+++ b/resources/server/marketplace/marketplace.db.ts
@@ -1,5 +1,4 @@
 import { MarketplaceListing, MarketplaceListingBase } from '../../../typings/marketplace';
-import { ResultSetHeader } from 'mysql2';
 import DbInterface from '../db/db_wrapper';
 
 export class _MarketplaceDB {
@@ -13,7 +12,7 @@ export class _MarketplaceDB {
     const query =
       'INSERT INTO npwd_marketplace_listings (identifier, username, name, number, title, url, description) VALUES (?, ?, ?, ?, ?, ?, ?)';
 
-    const [result] = await DbInterface._rawExec(query, [
+    const insertId = await DbInterface.insert(query, [
       identifier,
       username,
       name,
@@ -23,44 +22,42 @@ export class _MarketplaceDB {
       listing.description,
     ]);
 
-    const resultCast = result as ResultSetHeader;
-
-    return resultCast.insertId;
+    return insertId;
   }
 
   async fetchListings(): Promise<MarketplaceListing[]> {
     const query = 'SELECT * FROM npwd_marketplace_listings ORDER BY id DESC';
 
-    const [results] = await DbInterface._rawExec(query);
+    const results = await DbInterface.fetch(query);
     return <MarketplaceListing[]>results;
   }
 
   async deleteListing(listingId: number, identifier: string): Promise<void> {
     const query = 'DELETE FROM npwd_marketplace_listings WHERE id = ? AND identifier = ?';
 
-    await DbInterface._rawExec(query, [listingId, identifier]);
+    await DbInterface.exec(query, [listingId, identifier]);
   }
 
   async deleteListingsOnDrop(identifier: string) {
     const query = `DELETE FROM npwd_marketplace_listings WHERE identifier = ?`;
-    await DbInterface._rawExec(query, [identifier]);
+    await DbInterface.exec(query, [identifier]);
   }
 
   async getListing(listingId: number): Promise<MarketplaceListing> {
     const query = `SELECT * FROM npwd_marketplace_listings WHERE id = ?`;
-    const [results] = await DbInterface._rawExec(query, [listingId]);
+    const results = await DbInterface.fetch(query, [listingId]);
     const listings = <MarketplaceListing[]>results;
     return listings[0];
   }
 
   async reportListing(listingId: number, profile: string): Promise<void> {
     const query = `INSERT INTO npwd_marketplace_reports (listing_id, profile) VALUES (?, ?)`;
-    await DbInterface._rawExec(query, [listingId, profile]);
+    await DbInterface.insert(query, [listingId, profile]);
   }
 
   async doesReportExist(listingId: number, profile: string): Promise<boolean> {
     const query = `SELECT * FROM npwd_marketplace_reports WHERE listing_id = ? AND profile = ?`;
-    const [results] = await DbInterface._rawExec(query, [listingId, profile]);
+    const results = await DbInterface.fetch(query, [listingId, profile]);
     const result = <any>results;
 
     return result.length > 0;

--- a/resources/server/match/match.db.ts
+++ b/resources/server/match/match.db.ts
@@ -34,7 +34,7 @@ export class _MatchDB {
         ORDER BY npwd_match_profiles.updatedAt DESC
         LIMIT 25
 		`;
-    const [results] = await DbInterface._rawExec(query, [identifier, identifier]);
+    const results = await DbInterface.fetch(query, [identifier, identifier]);
     return <Profile[]>results;
   }
 
@@ -49,7 +49,7 @@ export class _MatchDB {
                    VALUES ?`;
     const formattedLikes = likes.map((like) => [identifier, like.id, like.liked]);
 
-    const results = await DbInterface._rawExec(query, [formattedLikes]);
+    const results = await DbInterface.fetch(query, [formattedLikes]);
     return <ResultSetHeader[]>results;
   }
 
@@ -72,7 +72,7 @@ export class _MatchDB {
           AND targetProfile.id = ?
           AND Liked = 1
 		`;
-    const [results] = await DbInterface._rawExec(query, [identifier, id]);
+    const results = await DbInterface.fetch(query, [identifier, id]);
     return <Profile[]>results;
   }
 
@@ -100,7 +100,7 @@ export class _MatchDB {
           AND targetViews.liked = 1
         ORDER BY matchedAt DESC
 		`;
-    const [results] = await DbInterface._rawExec(query, [identifier]);
+    const results = await DbInterface.fetch(query, [identifier]);
     return <Match[]>results;
   }
 
@@ -117,7 +117,7 @@ export class _MatchDB {
         WHERE identifier = ?
         LIMIT 1
 		`;
-    const [results] = await DbInterface._rawExec(query, [identifier]);
+    const results = await DbInterface.fetch(query, [identifier]);
     const profiles = <Profile[]>results;
     return profiles[0];
   }

--- a/resources/server/misc/functions.ts
+++ b/resources/server/misc/functions.ts
@@ -5,10 +5,10 @@ import { playerLogger } from '../players/player.utils';
 
 export async function findOrGeneratePhoneNumber(identifier: string): Promise<string> {
   const query = `SELECT ${config.database.phoneNumberColumn} FROM ${config.database.playerTable} WHERE ${config.database.identifierColumn} = ? LIMIT 1`;
-  const res = await DbInterface.fetch(query, [identifier]);
+  const result = await DbInterface.fetch(query, [identifier]);
 
-  if (res && res[0][config.database.phoneNumberColumn])
-    return res[0][config.database.phoneNumberColumn] as string;
+  if (result && result[0][config.database.phoneNumberColumn])
+    return result[0][config.database.phoneNumberColumn] as string;
 
   playerLogger.debug('Phone number was returned as null, generating new number');
   const gennedNumber = await generateUniquePhoneNumber();

--- a/resources/server/misc/functions.ts
+++ b/resources/server/misc/functions.ts
@@ -5,15 +5,10 @@ import { playerLogger } from '../players/player.utils';
 
 export async function findOrGeneratePhoneNumber(identifier: string): Promise<string> {
   const query = `SELECT ${config.database.phoneNumberColumn} FROM ${config.database.playerTable} WHERE ${config.database.identifierColumn} = ? LIMIT 1`;
-  const [res] = await DbInterface._rawExec(query, [identifier]);
+  const res = await DbInterface.fetch(query, [identifier]);
 
-  playerLogger.debug('Find user for number generation data >');
-  playerLogger.debug(res);
-
-  const castRes = res as Record<string, unknown>[];
-
-  if (castRes && castRes[0][config.database.phoneNumberColumn] !== null)
-    return castRes[0][config.database.phoneNumberColumn] as string;
+  if (res && res[0][config.database.phoneNumberColumn])
+    return res[0][config.database.phoneNumberColumn] as string;
 
   playerLogger.debug('Phone number was returned as null, generating new number');
   const gennedNumber = await generateUniquePhoneNumber();
@@ -22,7 +17,7 @@ export async function findOrGeneratePhoneNumber(identifier: string): Promise<str
 
   const updateQuery = `UPDATE ${config.database.playerTable} SET ${config.database.phoneNumberColumn} = ? WHERE ${config.database.identifierColumn} = ?`;
   // Update profile with new generated number
-  await DbInterface._rawExec(updateQuery, [gennedNumber, identifier]);
+  await DbInterface.exec(updateQuery, [gennedNumber, identifier]);
 
   return gennedNumber;
 }

--- a/resources/server/misc/generateUniquePhoneNumber.ts
+++ b/resources/server/misc/generateUniquePhoneNumber.ts
@@ -25,10 +25,10 @@ const generateUsNumber = (): string => {
 
 /**/
 export async function generateUniquePhoneNumber(): Promise<string> {
-  const query = `SELECT EXISTS(SELECT * FROM ${config.database.playerTable} WHERE ${config.database.phoneNumberColumn} = ?)`;
+  const query = `SELECT EXISTS(SELECT 1 FROM ${config.database.playerTable} WHERE ${config.database.phoneNumberColumn} = ?)`;
   const dashNumber = generateUsNumber();
 
-  const [results] = await DbInterface._rawExec(query, dashNumber);
+  const results = await DbInterface.fetch(query, dashNumber);
 
   if (!results) return generateUniquePhoneNumber();
 

--- a/resources/server/notes/notes.db.ts
+++ b/resources/server/notes/notes.db.ts
@@ -1,28 +1,27 @@
 import { BeforeDBNote, NoteItem } from '../../../typings/notes';
-import { ResultSetHeader } from 'mysql2';
 import DbInterface from '../db/db_wrapper';
 
 export class _NotesDB {
   async addNote(identifier: string, note: BeforeDBNote): Promise<number> {
     const query = 'INSERT INTO npwd_notes (identifier, title, content) VALUES (?, ?, ?)';
-    const [result] = await DbInterface._rawExec(query, [identifier, note.title, note.content]);
-    return (<ResultSetHeader>result).insertId;
+    const insertId = await DbInterface.insert(query, [identifier, note.title, note.content]);
+    return insertId;
   }
 
   async fetchNotes(identifier: string): Promise<NoteItem[]> {
     const query = 'SELECT * FROM npwd_notes WHERE identifier = ? ORDER BY id DESC';
-    const [result] = await DbInterface._rawExec(query, [identifier]);
+    const result = await DbInterface.fetch(query, [identifier]);
     return <NoteItem[]>result;
   }
 
   async deleteNote(noteId: number, identifier: string): Promise<void> {
     const query = 'DELETE FROM npwd_notes WHERE id = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [noteId, identifier]);
+    await DbInterface.exec(query, [noteId, identifier]);
   }
 
   async updateNote(note: NoteItem, identifier: string): Promise<void> {
     const query = 'UPDATE npwd_notes SET title = ?, content = ? WHERE id = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [note.title, note.content, note.id, identifier]);
+    await DbInterface.exec(query, [note.title, note.content, note.id, identifier]);
   }
 }
 

--- a/resources/server/photo/photo.db.ts
+++ b/resources/server/photo/photo.db.ts
@@ -4,19 +4,19 @@ import DbInterface from '../db/db_wrapper';
 export class _PhotoDB {
   async uploadPhoto(identifier: string, image: string): Promise<GalleryPhoto> {
     const query = 'INSERT INTO npwd_phone_gallery (identifier, image) VALUES (?, ?)';
-    const [results] = (await DbInterface._rawExec(query, [identifier, image])) as any;
+    const results = (await DbInterface.fetch(query, [identifier, image])) as any;
     return { id: results.insertId, image };
   }
 
   async getPhotosByIdentifier(identifier: string): Promise<GalleryPhoto[]> {
     const query = 'SELECT id, image FROM npwd_phone_gallery WHERE identifier = ? ORDER BY id DESC';
-    const [results] = await DbInterface._rawExec(query, [identifier]);
+    const results = await DbInterface.fetch(query, [identifier]);
     return <GalleryPhoto[]>results;
   }
 
   async deletePhoto(photo: GalleryPhoto, identifier: string) {
     const query = 'DELETE FROM npwd_phone_gallery WHERE image = ? AND identifier = ?';
-    await DbInterface._rawExec(query, [photo.image, identifier]);
+    await DbInterface.exec(query, [photo.image, identifier]);
   }
 }
 

--- a/resources/server/players/player.db.ts
+++ b/resources/server/players/player.db.ts
@@ -4,9 +4,9 @@ import DbInterface from '../db/db_wrapper';
 export class PlayerRepo {
   async fetchIdentifierFromPhoneNumber(phoneNumber: string): Promise<string | null> {
     const query = `SELECT ${config.database.identifierColumn} FROM ${config.database.playerTable} WHERE ${config.database.phoneNumberColumn} = ?`;
-    const [results] = await DbInterface._rawExec(query, [phoneNumber]);
+    const results = await DbInterface.fetch(query, [phoneNumber]);
     // Get identifier from results
-    return (results as any[])[0][config.database.identifierColumn] || null;
+    return results[0][config.database.identifierColumn] || null;
   }
 }
 

--- a/resources/server/utils/withProfile.ts
+++ b/resources/server/utils/withProfile.ts
@@ -2,8 +2,6 @@ import { mainLogger } from '../sv_logger';
 
 const profilerLog = mainLogger.child({ module: 'profiler' });
 
-const RESOURCE_NAME = GetCurrentResourceName();
-
 // Simple higher order function profiler
 // currently targeted towards ms as unit and db queries
 // but can be altered to be generic in future
@@ -11,7 +9,6 @@ export const withProfile = async (fn: Function, ...args: any[]) => {
   const startTime = process.hrtime.bigint();
 
   // https://forum.cfx.re/t/node-mysql2-question-about-performance-process-nexttick/4550064/2?u=taso
-  ScheduleResourceTick(RESOURCE_NAME);
   const res = await fn(...args);
 
   const endTime = process.hrtime.bigint();

--- a/resources/yarn.lock
+++ b/resources/yarn.lock
@@ -1152,11 +1152,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@citizenfx/client@^1.0.1688-1":
-  version "1.0.1688-1"
-  resolved "https://registry.yarnpkg.com/@citizenfx/client/-/client-1.0.1688-1.tgz#360c5db391cf9662b81129b84eaa35299d604ef5"
-  integrity sha512-RUnWSBalc888c/HheM+aOu6oHCa1QDmCzbgyldyLQfcq2B8uPfrKkogZenC3iR0vBB/bTdb+2NU4q/VhIU4V4Q==
-
 "@citizenfx/client@^1.0.3281-1":
   version "1.0.3281-1"
   resolved "https://registry.yarnpkg.com/@citizenfx/client/-/client-1.0.3281-1.tgz#e26d85cb3686f8e0c85fdb86dca159e027358418"
@@ -2955,13 +2950,6 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-connection-string-parser@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/connection-string-parser/-/connection-string-parser-1.0.4.tgz#27f1379694fccd7c1c0066db3de0960f9d0dd619"
-  integrity sha512-grmrIHzrZRjn53dwRqJTmtTRVc+gUiIk/tzjUrteN6aLN4l9DR6KE/IsGtjndyAlHhkmKjAHB9p7PJ0cFgO94w==
-  dependencies:
-    tslib "^2.0.0"
-
 console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
@@ -3571,11 +3559,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-esx.js@^1.1.6:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/esx.js/-/esx.js-1.1.8.tgz#ad9d8532e755a93d5ee5c45c2224a3f9068ea5a2"
-  integrity sha512-7/dwj/w99/ke2RJUFGqJbBA3Qf7Gj7t+GZ6ckCW406EQz/GiaVKvibJZ83GTigIH3JZaBwsj6zgu0AF8wqTd9w==
-
 events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -3820,14 +3803,6 @@ findup-sync@^3.0.0:
     is-glob "^4.0.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
-
-fivem-esx-js@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/fivem-esx-js/-/fivem-esx-js-0.1.12.tgz#269bdfef84ed1500f19eb5f2fb7087f5cb5e5353"
-  integrity sha512-gUSt9lll66FVBuNYP5kJVuXwU5jjg2rAaldembGRHJTAHd1WdMRIPF9899omUeJf4m4ToyfekxjcYtbttLrIJg==
-  dependencies:
-    "@citizenfx/client" "^1.0.1688-1"
-    fivem-js "^1.3.1"
 
 fivem-js@^1.3.1:
   version "1.5.2"
@@ -7222,11 +7197,6 @@ tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
**Pull Request Description**

Start replacing the calls to the deprecated DbInterface._rawExec function and ensure proper typecasting.
- Utilise pool.execute over pool.query (may need to adjust some queries)
- Ensure proper return values/types

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
