### PR TITLE
Gh 348/repopulate conversations

### DIFF
--- a/phone/src/locale/en.json
+++ b/phone/src/locale/en.json
@@ -202,7 +202,7 @@
         "NEW_MESSAGE_FAILED": "Failed to send message",
         "INVALID_PHONE_NUMBER": "Invalid phone number",
         "MESSAGE_CONVERSATION_DUPLICATE": "This conversation already exists!",
-        "MESSAGE_GROUP_CREATE_FAILED": "Failed to create message group",
+        "MESSAGE_GROUP_CREATE_FAILED": "Failed to create message conversation",
         "MESSAGE_GROUP_CREATE_MINE": "You cannot add yourself!",
         "FETCHED_MESSAGES_FAILED": "Failed to retrieve messages",
         "DELETE_MESSAGE": "Delete message",

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -14,7 +14,6 @@ import {
 } from './messages.utils';
 import { PromiseEventResp, PromiseRequest } from '../lib/PromiseNetEvents/promise.types';
 
-// felt good to just remove group chats.
 class _MessagesService {
   private readonly messagesDB: _MessagesDB;
 
@@ -25,7 +24,6 @@ class _MessagesService {
 
   async handleFetchMessageConversations(reqObj: PromiseRequest, resp: PromiseEventResp<any>) {
     try {
-      //const identifier = PlayerService.getIdentifier(reqObj.source);
       const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
       const messageConversations = await getFormattedMessageConversations(phoneNumber);
 


### PR DESCRIPTION
**Pull Request Description**

Create a message conversation for the receiving client when a message broadcast is emitted.
The introduced feature is not final, nor should it be. 

Messages needs to refactor into having API and "local" nui functionality (not doing that now)

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [ ] Have you built and tested NPWD in-game after the relevant change? No.
