### PR TITLE
tweak(config): improve name convention for resource integration config

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
     "exportFunction": "myCheckerFunction"
   },
   "general": {
-    "enableMultiChar": false
+    "useResourceIntegration": false
   },
   "database": {
     "useIdentifierPrefix": false,

--- a/resources/server/bridge/sv_exports.ts
+++ b/resources/server/bridge/sv_exports.ts
@@ -22,7 +22,7 @@ exp('generatePhoneNumber', async () => {
 // For multicharacter frameworks, we enable these events for
 // instantiating/deleting a player. The config option must be set to true
 // for these to be available
-if (config.general.enableMultiChar) {
+if (config.general.useResourceIntegration) {
   exp('newPlayer', async (playerDTO: PlayerAddData) => {
     if (typeof playerDTO.source !== 'number') {
       return playerLogger.error('Source must be passed as a number when loading a player');

--- a/resources/server/players/player.controller.ts
+++ b/resources/server/players/player.controller.ts
@@ -20,7 +20,7 @@ onNet(PhoneEvents.FETCH_CREDENTIALS, () => {
 // If multicharacter mode is disabled, we instantiate a new
 // NPWD player by ourselves without waiting for an export
 
-if (!config.general.enableMultiChar) {
+if (!config.general.useResourceIntegration) {
   on('playerJoining', async () => {
     const src = getSource();
     await PlayerService.handleNewPlayerJoined(src);
@@ -49,7 +49,7 @@ on('playerDropped', async () => {
 
 // Used for debug purposes, if the resource is restarted and the multicharacter option is false
 // we will handle all the currently online players
-if (!config.general.enableMultiChar) {
+if (!config.general.useResourceIntegration) {
   on('onServerResourceStart', async (resource: string) => {
     if (resource === GetCurrentResourceName()) {
       const onlinePlayers = getPlayers();

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -25,7 +25,7 @@ interface Debug {
 
 interface General {
   useDashNumber: boolean;
-  enableMultiChar: boolean;
+  useResourceIntegration: boolean;
 }
 
 interface NotificationConfig {


### PR DESCRIPTION
Rename 'enableMultiChar' to 'useResourceIntegration'. Better name convention, and *hopefully* less confusion
