### PR TITLE
refactor(db): change mysql_connection_string parsing

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -17,7 +17,6 @@
     "@discordjs/collection": "^0.2.4",
     "@project-error/pe-utils": "^0.1.6",
     "axios": "^0.21.4",
-    "connection-string-parser": "^1.0.4",
     "dayjs": "^1.10.7",
     "fivem-js": "^1.3.1",
     "md5": "^2.3.0",

--- a/resources/server/db/db_utils.test.ts
+++ b/resources/server/db/db_utils.test.ts
@@ -1,93 +1,19 @@
 import * as db from './db_utils';
-
-const t = 'test value';
+const testStrings = [
+  'server=127.0.0.1;database=es_extended;userid=user',
+  'host=127.0.0.1;database=es_extended;userid=user;',
+  'addr=127.0.0.1;;db=es_extended;uid=user;;',
+];
 
 describe('parseSemiColonFormat', () => {
-  it('Raises a error with invalid string', () => {
-    expect(() => db.parseSemiColonFormat('no_variables_here')).toThrowError();
-  });
+  testStrings.forEach((test) => {
+    it('Correctly parses configuration options', () => {
+      const result = db.parseSemiColonFormat(test);
 
-  it('Correctly parses configuration options', () => {
-    const test = 'server=127.0.0.1;database=es_extended;userid=user;';
-    const result = db.parseSemiColonFormat(test);
-
-    expect(result.server).toEqual('127.0.0.1');
-    expect(result.database).toEqual('es_extended');
-    expect(result.userid).toEqual('user');
-    expect(result.password).toEqual(undefined);
-  });
-});
-
-describe('getServerHost', () => {
-  it('returns default', () => {
-    expect(db.getServerHost({})).toEqual(db.DEFAULT_HOST);
-  });
-
-  it('Correctly returns host', () => {
-    expect(db.getServerHost({ host: t })).toEqual(t);
-  });
-
-  it('Correctly returns server', () => {
-    expect(db.getServerHost({ server: t })).toEqual(t);
-  });
-
-  it('Correctly returns data source', () => {
-    expect(db.getServerHost({ 'data source': t })).toEqual(t);
-  });
-
-  it('Correctly returns datasource', () => {
-    expect(db.getServerHost({ datasource: t })).toEqual(t);
-  });
-
-  it('Correctly returns addr', () => {
-    expect(db.getServerHost({ addr: t })).toEqual(t);
-  });
-
-  it('Correctly returns address', () => {
-    expect(db.getServerHost({ address: t })).toEqual(t);
-  });
-});
-
-describe('getUserId', () => {
-  it('returns default', () => {
-    expect(db.getUserId({})).toEqual(db.DEFAULT_USER);
-  });
-
-  it('Correctly returns user', () => {
-    expect(db.getUserId({ user: t })).toEqual(t);
-  });
-
-  it('Correctly returns user id', () => {
-    expect(db.getUserId({ 'user id': t })).toEqual(t);
-  });
-
-  it('Correctly returns userid', () => {
-    expect(db.getUserId({ userid: t })).toEqual(t);
-  });
-
-  it('Correctly returns user name', () => {
-    expect(db.getUserId({ 'user name': t })).toEqual(t);
-  });
-
-  it('Correctly returns username', () => {
-    expect(db.getUserId({ username: t })).toEqual(t);
-  });
-
-  it('Correctly returns uid', () => {
-    expect(db.getUserId({ uid: t })).toEqual(t);
-  });
-});
-
-describe('getPassword', () => {
-  // it("returns default", () => {
-  //   expect(() => db.getPassword({})).toThrowError();
-  // });
-
-  it('Correctly returns password', () => {
-    expect(db.getPassword({ password: t })).toEqual(t);
-  });
-
-  it('Correctly returns pwd', () => {
-    expect(db.getPassword({ pwd: t })).toEqual(t);
+      expect(result.host).toEqual('127.0.0.1');
+      expect(result.database).toEqual('es_extended');
+      expect(result.user).toEqual('user');
+      expect(result.password).toEqual(undefined);
+    });
   });
 });

--- a/resources/server/db/db_utils.ts
+++ b/resources/server/db/db_utils.ts
@@ -1,8 +1,4 @@
 export const CONNECTION_STRING = 'mysql_connection_string';
-export const DEFAULT_PORT = 3306;
-export const DEFAULT_HOST = 'localhost';
-export const DEFAULT_USER = 'root';
-
 interface Map {
   [key: string]: string;
 }
@@ -12,59 +8,22 @@ interface Map {
  * @param connectionString - mysql_connection_string value
  */
 export function parseSemiColonFormat(connectionString: string): Map {
-  const parts = connectionString.split(';');
+  const parts = connectionString
+    .replace(/(?:host(?:name)|ip|server|data\s?source|addr(?:ess)?)=/gi, 'host=')
+    .replace(/(?:user\s?(?:id|name)?|uid)=/gi, 'user=')
+    .replace(/(?:pwd|pass)=/gi, 'password=')
+    .replace(/(?:db)=/gi, 'database=')
+    .split(';');
+
   if (parts.length === 1) {
     throw new Error(
       `Connection string ${connectionString} is in the incorrect format. Please follow the README.`,
     );
   }
 
-  return parts.reduce((connectionInfo: Map, part) => {
-    const [key, value] = part.split('=');
-    connectionInfo[key] = value;
+  return parts.reduce<Record<string, string>>((connectionInfo, parameter) => {
+    const [key, value] = parameter.split('=');
+    if (value) connectionInfo[key] = value;
     return connectionInfo;
   }, {});
-}
-
-/**
- * allowed variable names: host | server | data source | datasource | addr | address
- * @param config - database config variables parsed from mysql_connection_string
- */
-export function getServerHost(config: Map): string {
-  return (
-    config.host ||
-    config.server ||
-    config['data source'] ||
-    config.datasource ||
-    config.addr ||
-    config.address ||
-    DEFAULT_HOST
-  );
-}
-
-/**
- * allowed variable names: user | user id | userid | user name | username | uid
- * @param config - database config variables parsed from mysql_connection_string
- */
-export function getUserId(config: Map): string {
-  return (
-    config.user ||
-    config['user id'] ||
-    config.userid ||
-    config['user name'] ||
-    config.username ||
-    config.uid ||
-    DEFAULT_USER
-  );
-}
-
-/**
- * Note: We are allowing no password as many FiveM servers love to not use one for an ungodly reason.
- * allowed variable names: password | pwd
- * @param config - database config variables parsed from mysql_connection_string
- */
-export function getPassword(config: Map): string | undefined {
-  const password = config.password || config.pwd;
-  if (!password) return undefined;
-  return password;
 }


### PR DESCRIPTION
**Pull Request Description**

Utilises the built-in parser from mysql-2 when string contains `mysql://`, otherwise uses the (improved) semicolon parser.
This brings the parser in-line with oxmysql which has more compatibility with mysql-async strings than the current one.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
