### PR TITLE
feat: basic image filtering

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,20 @@
     "useAuthorization": true,
     "returnedDataIndexes": ["data", "link"]
   },
+  "imageSafety": {
+    "filterUnsafeImageUrls": true,
+    "embedUnsafeImages": false,
+    "embedUrl": "https://i.example.com/embed",
+    "safeImageUrls": [
+      "imgur.com",
+      "file.glass",
+      "dropbox.com",
+      "tenor.com",
+      "discord.com",
+      "discordapp.com",
+      "wikipedia.org"
+    ]
+  },
   "twitter": {
     "showNotifications": true,
     "generateProfileNameFromUsers": true,

--- a/phone/src/apps/camera/components/grid/GalleryGrid.tsx
+++ b/phone/src/apps/camera/components/grid/GalleryGrid.tsx
@@ -34,8 +34,10 @@ export const GalleryGrid = () => {
     setIsLoading(true);
     fetchNui<ServerPromiseResp<GalleryPhoto>>(PhotoEvents.TAKE_PHOTO).then((serverResp) => {
       if (serverResp.status !== 'ok') {
+        // We do early returns so we want to unset the loading here
+        setIsLoading(false);
         return addAlert({
-          message: t('CAMERA.FAILED_TO_TAKE_PHOTO'),
+          message: t(serverResp.errorMsg),
           type: 'error',
         });
       }

--- a/phone/src/apps/contacts/hooks/useContactsAPI.ts
+++ b/phone/src/apps/contacts/hooks/useContactsAPI.ts
@@ -22,7 +22,7 @@ export const useContactsAPI = () => {
       }).then((serverResp) => {
         if (serverResp.status !== 'ok') {
           return addAlert({
-            message: t('CONTACTS.FEEDBACK.ADD_FAILED'),
+            message: t(serverResp.errorMsg),
             type: 'error',
           });
         }
@@ -49,7 +49,7 @@ export const useContactsAPI = () => {
       }).then((resp) => {
         if (resp.status !== 'ok') {
           return addAlert({
-            message: t('CONTACTS.FEEDBACK.UPDATE_FAILED'),
+            message: t(resp.errorMsg),
             type: 'error',
           });
         }

--- a/phone/src/apps/marketplace/components/form/ListingForm.tsx
+++ b/phone/src/apps/marketplace/components/form/ListingForm.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import { Box, Button } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import {
-  ListingTypeResp,
+  MarketplaceResp,
   MarketplaceDatabaseLimits,
   MarketplaceEvents,
 } from '@typings/marketplace';
@@ -62,18 +62,11 @@ export const ListingForm: React.FC = () => {
       });
     }
 
-    fetchNui<ServerPromiseResp<ListingTypeResp>>(MarketplaceEvents.ADD_LISTING, formState).then(
+    fetchNui<ServerPromiseResp<MarketplaceResp>>(MarketplaceEvents.ADD_LISTING, formState).then(
       (resp) => {
         if (resp.status !== 'ok') {
-          if (resp.data === ListingTypeResp.DUPLICATE) {
-            return addAlert({
-              message: t('MARKETPLACE.FEEDBACK.DUPLICATE_LISTING'),
-              type: 'error',
-            });
-          }
-
           return addAlert({
-            message: t('MARKETPLACE.FEEDBACK.CREATE_LISTING_FAILED'),
+            message: t(resp.errorMsg),
             type: 'error',
           });
         }

--- a/phone/src/apps/match/components/profile/ProfileForm.tsx
+++ b/phone/src/apps/match/components/profile/ProfileForm.tsx
@@ -77,7 +77,7 @@ export function ProfileForm({ profile, showPreview }: IProps) {
     fetchNui<ServerPromiseResp<FormattedProfile>>(event, updatedProfile).then((resp) => {
       if (resp.status !== 'ok') {
         return addAlert({
-          message: t('MATCH.FEEDBACK.UPDATE_PROFILE_FAILED'),
+          message: t(resp.errorMsg),
           type: 'error',
         });
       }

--- a/phone/src/apps/twitter/components/profile/Profile.tsx
+++ b/phone/src/apps/twitter/components/profile/Profile.tsx
@@ -66,7 +66,7 @@ export function Profile() {
     fetchNui<ServerPromiseResp>(TwitterEvents.UPDATE_PROFILE, data).then((resp) => {
       if (resp.status !== 'ok') {
         return addAlert({
-          message: t(''),
+          message: t(resp.errorMsg),
           type: 'error',
         });
       }

--- a/phone/src/locale/en.json
+++ b/phone/src/locale/en.json
@@ -290,6 +290,8 @@
     "GENERIC_TITLE": "Title",
     "GENERIC_CONTENT": "Content",
     "GENERIC_WRITE_TO_CLIPBOARD_TOOLTIP": "Copy {{ content }}",
-    "GENERIC_WRITE_TO_CLIPBOARD_MESSAGE": "Copied {{content}} to clipboard!"
+    "GENERIC_WRITE_TO_CLIPBOARD_MESSAGE": "Copied {{content}} to clipboard!",
+    "GENERIC_DB_ERROR": "Create/update request failed.",
+    "GENERIC_INVALID_IMAGE_HOST": "The image host you tried to use is not allowed by this server."
   }
 }

--- a/resources/client/cl_photo.ts
+++ b/resources/client/cl_photo.ts
@@ -57,16 +57,11 @@ RegisterNuiCB<void>(PhotoEvents.TAKE_PHOTO, async (_, cb) => {
     if (IsControlJustPressed(1, 27)) {
       frontCam = !frontCam;
       CellFrontCamActivate(frontCam);
-    // Enter Key, Take Photo
+      // Enter Key, Take Photo
     } else if (IsControlJustPressed(1, 176)) {
-      if (SCREENSHOT_BASIC_TOKEN !== 'none') {
-        const resp = await handleTakePicture();
-        cb(resp);
-        break;
-      }
-      console.error(
-        'You may be trying to take a photo, but your token is not setup for upload! See NPWD Docs for more info!',
-      );
+      const resp = await handleTakePicture();
+      cb(resp);
+      break;
     } else if (IsControlJustPressed(1, 194)) {
       await handleCameraExit();
       break;
@@ -87,15 +82,20 @@ const handleTakePicture = async () => {
   // Wait a frame so we don't draw the display helper text
   ClearHelp(true);
   await Delay(0);
+  /*
+   * If we don't do this janky work around players get stuck in their camera
+   * until the entire server callback has happened, which doesn't matter for
+   * people with fast internet but a lot of people still have slow internet
+   */
+  setTimeout(() => {
+    DestroyMobilePhone();
+    CellCamActivate(false, false);
+    openPhoneTemp();
+    animationService.openPhone();
+    emit('npwd:disableControlActions', true);
+  }, 200);
   const resp = await takePhoto();
-  DestroyMobilePhone();
-  CellCamActivate(false, false);
-  openPhoneTemp();
-  animationService.openPhone();
-  emit('npwd:disableControlActions', true);
-  await Delay(200);
   inCameraMode = false;
-
   return resp;
 };
 

--- a/resources/server/contacts/contacts.service.ts
+++ b/resources/server/contacts/contacts.service.ts
@@ -1,8 +1,9 @@
 import PlayerService from '../players/player.service';
 import { contactsLogger } from './contacts.utils';
 import ContactsDB, { _ContactsDB } from './contacts.db';
-import { Contact, ContactDeleteDTO, PreDBContact } from '../../../typings/contact';
+import { Contact, ContactDeleteDTO, ContactResp, PreDBContact } from '../../../typings/contact';
 import { PromiseEventResp, PromiseRequest } from '../lib/PromiseNetEvents/promise.types';
+import { checkAndFilterImage } from './../utils/imageFiltering';
 
 class _ContactService {
   private readonly contactsDB: _ContactsDB;
@@ -18,11 +19,16 @@ class _ContactService {
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
     try {
+      const imageUrl = checkAndFilterImage(reqObj.data.avatar);
+      if (imageUrl == null) {
+        return resp({ status: 'error', errorMsg: 'GENERIC_INVALID_IMAGE_HOST' });
+      }
+      reqObj.data.avatar = imageUrl;
       await this.contactsDB.updateContact(reqObj.data, identifier);
       resp({ status: 'ok' });
     } catch (e) {
       contactsLogger.error(`Error in handleUpdateContact (${identifier}), ${e.message}`);
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: ContactResp.UPDATE_FAILED });
     }
   }
   async handleDeleteContact(
@@ -34,7 +40,7 @@ class _ContactService {
       await this.contactsDB.deleteContact(reqObj.data.id, identifier);
       resp({ status: 'ok' });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       contactsLogger.error(`Error in handleDeleteContact (${identifier}), ${e.message}`);
     }
   }
@@ -44,12 +50,17 @@ class _ContactService {
   ): Promise<void> {
     const identifier = PlayerService.getIdentifier(reqObj.source);
     try {
+      const imageUrl = checkAndFilterImage(reqObj.data.avatar);
+      if (imageUrl == null) {
+        return resp({ status: 'error', errorMsg: 'GENERIC_INVALID_IMAGE_HOST' });
+      }
+      reqObj.data.avatar = imageUrl;
       const contact = await this.contactsDB.addContact(identifier, reqObj.data);
 
       resp({ status: 'ok', data: contact });
     } catch (e) {
       contactsLogger.error(`Error in handleAddContact, ${e.message}`);
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: ContactResp.ADD_FAILED });
     }
   }
   async handleFetchContacts(
@@ -61,7 +72,7 @@ class _ContactService {
       const contacts = await this.contactsDB.fetchAllContacts(identifier);
       resp({ status: 'ok', data: contacts });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       contactsLogger.error(`Error in handleFetchContact (${identifier}), ${e.message}`);
     }
   }

--- a/resources/server/marketplace/marketplace.controller.ts
+++ b/resources/server/marketplace/marketplace.controller.ts
@@ -1,5 +1,5 @@
 import {
-  ListingTypeResp,
+  MarketplaceResp,
   MarketplaceEvents,
   MarketplaceListing,
   MarketplaceListingBase,
@@ -19,7 +19,7 @@ onNetPromise<void, MarketplaceListing[]>(MarketplaceEvents.FETCH_LISTING, async 
   });
 });
 
-onNetPromise<MarketplaceListingBase, ListingTypeResp>(
+onNetPromise<MarketplaceListingBase, MarketplaceResp>(
   MarketplaceEvents.ADD_LISTING,
   async (reqObj, resp) => {
     MarketplaceService.handleAddListing(reqObj, resp).catch((e) => {

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -29,7 +29,7 @@ class _MessagesService {
 
       resp({ status: 'ok', data: messageConversations });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       messagesLogger.error(`Failed to fetch messages groups, ${e.message}`);
     }
   }
@@ -75,7 +75,7 @@ class _MessagesService {
         },
       });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
 
       messagesLogger.error(`Failed to create message group, ${e.message}`, {
         source: reqObj.source,
@@ -100,7 +100,7 @@ class _MessagesService {
 
       resp({ status: 'ok', data: messages });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       messagesLogger.error(`Failed to fetch messages, ${e.message}`, {
         source: reqObj.source,
       });
@@ -186,7 +186,7 @@ class _MessagesService {
       }
       resp({ status: 'ok' });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       messagesLogger.error(`Failed to delete conversation, ${e.message}`, {
         source: reqObj.source,
       });
@@ -198,7 +198,7 @@ class _MessagesService {
       await this.messagesDB.deleteMessage(reqObj.data);
       resp({ status: 'ok' });
     } catch (e) {
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
       messagesLogger.error(`Failed to delete message, ${e.message}`, {
         source: reqObj.source,
       });

--- a/resources/server/messages/messages.service.ts.rej
+++ b/resources/server/messages/messages.service.ts.rej
@@ -1,0 +1,10 @@
+diff a/resources/server/messages/messages.service.ts b/resources/server/messages/messages.service.ts	(rejected hunks)
+@@ -71,7 +71,7 @@ class _MessagesService {
+         data: { conversation_id: result.conversationId, phoneNumber: result.phoneNumber },
+       });
+     } catch (e) {
+-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
++      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
+ 
+       messagesLogger.error(`Failed to create message group, ${e.message}`, {
+         source: reqObj.source,

--- a/resources/server/notes/notes.service.ts
+++ b/resources/server/notes/notes.service.ts
@@ -30,7 +30,7 @@ class _NotesService {
     } catch (e) {
       notesLogger.error(`Error in handleAddNote, ${e.message}`);
 
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
     }
   }
 
@@ -41,7 +41,7 @@ class _NotesService {
       resp({ status: 'ok', data: notes });
     } catch (e) {
       notesLogger.error(`Error in handleFetchNote, ${e.message}`);
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
     }
   }
 
@@ -52,7 +52,7 @@ class _NotesService {
       resp({ status: 'ok' });
     } catch (e) {
       notesLogger.error(`Error in handleUpdateNote, ${e.message}`);
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
     }
   }
 
@@ -70,7 +70,7 @@ class _NotesService {
       resp({ status: 'ok', data: reqObj.data });
     } catch (e) {
       notesLogger.error(`Error in handleDeleteNote, ${e.message}`);
-      resp({ status: 'error', errorMsg: 'DB_ERROR' });
+      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
     }
   }
 }

--- a/resources/server/utils/imageFiltering.ts
+++ b/resources/server/utils/imageFiltering.ts
@@ -1,0 +1,21 @@
+import { config } from './../server';
+
+const imageRegex = new RegExp(config.imageSafety.safeImageUrls.join('|'));
+
+export const checkAndFilterImage = (imageUrl: string): string | null => {
+  const image = imageUrl.trim();
+  if (image == '') {
+    return image;
+  }
+
+  // If we don't care about filtering images just return the image
+  if (!config.imageSafety.filterUnsafeImageUrls) return image;
+
+  // We have an allowed image url!
+  if (imageRegex.test(image)) return image;
+
+  // Embed unsafe urls so we don't accidentally expose our users IP address
+  if (config.imageSafety.embedUnsafeImages) return `${config.imageSafety.embedUrl}?url=${imageUrl}`;
+
+  return null;
+};

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -48,6 +48,13 @@ interface DatabaseConfig {
   phoneNumberColumn: string;
 }
 
+interface ImageSafety {
+  filterUnsafeImageUrls: boolean;
+  embedUnsafeImages: boolean;
+  embedUrl: string;
+  safeImageUrls: string[];
+}
+
 interface ImageConfig {
   url: string;
   type: string;
@@ -76,4 +83,5 @@ export interface ResourceConfig {
   general: General;
   debug: Debug;
   images: ImageConfig;
+  imageSafety: ImageSafety;
 }

--- a/typings/contact.ts
+++ b/typings/contact.ts
@@ -20,6 +20,12 @@ export interface ContactDeleteDTO {
   id: number;
 }
 
+export enum ContactResp {
+  ADD_FAILED = 'CONTACT.FEEDBACK.ADD_FAILED',
+  UPDATE_FAILED = 'CONTACT.FEEDBACK.UPDATE_FAILED',
+  INVALID_HOST = 'GENERIC_INVALID_IMAGE_HOST',
+}
+
 export enum ContactsDatabaseLimits {
   avatar = 255,
   number = 20,

--- a/typings/marketplace.ts
+++ b/typings/marketplace.ts
@@ -18,8 +18,10 @@ export enum MarketplaceDatabaseLimits {
   url = 255,
 }
 
-export enum ListingTypeResp {
-  DUPLICATE = 'duplicate',
+export enum MarketplaceResp {
+  CREATE_FAILED = 'MARKETPLACE.FEEDBACK.CREATE_LISTING_FAILED',
+  DUPLICATE = 'MARKETPLACE.FEEDBACK.DUPLICATE_LISTING',
+  INVALID_IMAGE_HOST = 'GENERIC_INVALID_IMAGE_HOST',
 }
 
 export enum MarketplaceEvents {

--- a/typings/match.ts
+++ b/typings/match.ts
@@ -35,6 +35,10 @@ export interface Like {
   liked: boolean;
 }
 
+export enum MatchResp {
+  UPDATE_FAILED = 'MATCH.FEEDBACK.UPDATE_PROFILE_FAILED',
+}
+
 export enum MatchEvents {
   INITIALIZE = 'phone:initializeMatch',
   GET_PROFILES = 'phone:getMatchProfiles',

--- a/typings/photo.ts
+++ b/typings/photo.ts
@@ -3,6 +3,11 @@ export interface GalleryPhoto {
   id: number;
 }
 
+export enum PhotoResp {
+  GENERIC = 'CAMERA.FAILED_TO_TAKE_PHOTO',
+  INVALID_IMAGE_HOST = 'GENERIC_INVALID_IMAGE_HOST',
+}
+
 export enum PhotoEvents {
   TAKE_PHOTO = 'npwd:TakePhoto',
   CAMERA_EXITED = 'npwd:cameraExited',


### PR DESCRIPTION
This is a basic PR to get general ideas to improve "image safety".

The main current issue is that users are allowed to post images from any website, this isn't something that's unique to npwd and is something a lot of larger tech companies have something in place for. See `https://images-ext-2.discordapp.net/external/kPbHbSF3VICIZj3y5aDagCzU891BqQcHBtMzz3ygEkE/https/i.dillonskaggs.dev/RpptWjd0?width=245&height=300`

Why is this an issue?

The most obvious thing is that bad actors can IP dump the entire server if they have their own image server setup.

Current Missing Features:

- [x] update to handle multiple Twitter images
- [x] Filter match makers profile images
- [x] Filter Twitters avatar profile images
- [x] Filter marketplace images
- [x] Filter Contact images
- [x] Filter Gallery images
- [x] Return better error messages for declined images