### PR TITLE
Disable light melee attack

### DIFF
--- a/resources/client/cl_controls.lua
+++ b/resources/client/cl_controls.lua
@@ -35,6 +35,7 @@ CreateThread(function()
             DisableControlAction(0, 121, true)  -- Fly Camera (Flying)
             DisableControlAction(0, 122, true)  -- Control OVerride (Flying)
             DisableControlAction(0, 135, true)  -- Control OVerride (Sub)
+            DisableControlAction(0, 140, true)  -- Melee attack light
             DisableControlAction(0, 200, true)  -- Pause Menu
             DisableControlAction(0, 245, true)  -- Chat
         else


### PR DESCRIPTION
**Pull Request Description**

If your phone is open and another player is close to you, pressing R will trigger a light melee attack.
Disabling control 140 will fix it

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
