### PR TITLE
Feat/rewrite messages

### DIFF
--- a/import.sql
+++ b/import.sql
@@ -160,21 +160,6 @@ CREATE TABLE `npwd_messages_participants`
     CONSTRAINT `message_participants_npwd_messages_conversations_id_fk` FOREIGN KEY (`conversation_id`) REFERENCES `npwd_messages_conversations` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT
 );
 
-CREATE TABLE IF NOT EXISTS `npwd_messages_conversations`
-(
-    `id`                     int(11)      NOT NULL AUTO_INCREMENT,
-    `user_identifier`        varchar(48)  NOT NULL,
-    `createdAt`              timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-    `updatedAt`              timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP,
-    `conversation_id`        varchar(512) NOT NULL,
-    `participant_identifier` varchar(48)  NOT NULL,
-    `label`                  varchar(60)           DEFAULT '',
-    `unreadCount`            int(11)      NOT NULL DEFAULT 0,
-    `unread`                 int(11)               DEFAULT NULL,
-    PRIMARY KEY (id),
-    INDEX `user_identifier` (`user_identifier`)
-);
-
 CREATE TABLE `npwd_messages_conversations`
 (
     `id`                INT(11)      NOT NULL AUTO_INCREMENT,

--- a/import.sql
+++ b/import.sql
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS `npwd_marketplace_listings`
     `createdAt`   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updatedAt`   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     `reported`    tinyint      NOT NULL DEFAULT 0,
-        PRIMARY KEY (id),
+    PRIMARY KEY (id),
     INDEX `identifier` (`identifier`)
 );
 
@@ -149,6 +149,17 @@ CREATE TABLE IF NOT EXISTS `npwd_messages`
     INDEX `user_identifier` (`user_identifier`)
 );
 
+CREATE TABLE `npwd_messages_participants`
+(
+    `id`              INT(11)      NOT NULL AUTO_INCREMENT,
+    `conversation_id` INT(11)      NOT NULL,
+    `participant`     VARCHAR(225) NOT NULL COLLATE 'utf8mb4_general_ci',
+    `unread_count`    INT(11)      NULL DEFAULT '0',
+    PRIMARY KEY (`id`) USING BTREE,
+    INDEX `message_participants_npwd_messages_conversations_id_fk` (`conversation_id`) USING BTREE,
+    CONSTRAINT `message_participants_npwd_messages_conversations_id_fk` FOREIGN KEY (`conversation_id`) REFERENCES `npwd_messages_conversations` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT
+);
+
 CREATE TABLE IF NOT EXISTS `npwd_messages_conversations`
 (
     `id`                     int(11)      NOT NULL AUTO_INCREMENT,
@@ -163,6 +174,18 @@ CREATE TABLE IF NOT EXISTS `npwd_messages_conversations`
     PRIMARY KEY (id),
     INDEX `user_identifier` (`user_identifier`)
 );
+
+CREATE TABLE `npwd_messages_conversations`
+(
+    `id`                INT(11)      NOT NULL AUTO_INCREMENT,
+    `conversation_list` VARCHAR(225) NOT NULL COLLATE 'utf8mb4_general_ci',
+    `label`             VARCHAR(60)  NULL     DEFAULT '' COLLATE 'utf8mb4_general_ci',
+    `createdAt`         TIMESTAMP    NOT NULL DEFAULT current_timestamp(),
+    `last_message_id`   INT(11)      NULL     DEFAULT NULL,
+    `is_group_chat`     TINYINT(4)   NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`) USING BTREE
+);
+
 CREATE TABLE IF NOT EXISTS `npwd_calls`
 (
     `id`          int(11)      NOT NULL AUTO_INCREMENT,

--- a/phone/src/apps/contacts/utils/constants.ts
+++ b/phone/src/apps/contacts/utils/constants.ts
@@ -20,7 +20,7 @@ export const BrowserContactsState: Contact[] = [
   },
   {
     id: 4,
-    display: 'Kidz',
+    display: 'Avarian',
     number: '444-4444',
   },
 ];

--- a/phone/src/apps/messages/components/form/MessageInput.tsx
+++ b/phone/src/apps/messages/components/form/MessageInput.tsx
@@ -5,7 +5,8 @@ import SendIcon from '@mui/icons-material/Send';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import { TextField } from '@ui/components/Input';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
-import { MessageConversation } from '../../../../../../typings/messages';
+import { MessageConversation } from '@typings/messages';
+import useMessages from '../../hooks/useMessages';
 
 interface IProps {
   onAddImageClick(): void;
@@ -17,11 +18,14 @@ const MessageInput = ({ messageConversation, onAddImageClick }: IProps) => {
   const [t] = useTranslation();
   const [message, setMessage] = useState('');
   const { sendMessage } = useMessageAPI();
+  const { activeMessageConversation } = useMessages();
 
   const handleSubmit = async () => {
+    console.log(activeMessageConversation);
     if (message.trim()) {
       await sendMessage({
         conversationId: messageConversation.id,
+        conversationList: activeMessageConversation.conversationList,
         message,
         tgtPhoneNumber: messageConversation.participant,
       });

--- a/phone/src/apps/messages/components/form/MessageInput.tsx
+++ b/phone/src/apps/messages/components/form/MessageInput.tsx
@@ -21,9 +21,9 @@ const MessageInput = ({ messageConversation, onAddImageClick }: IProps) => {
   const handleSubmit = async () => {
     if (message.trim()) {
       await sendMessage({
-        conversationId: messageConversation.conversation_id,
+        conversationId: messageConversation.id,
         message,
-        tgtPhoneNumber: messageConversation.phoneNumber,
+        tgtPhoneNumber: messageConversation.participant,
       });
       setMessage('');
     }
@@ -35,7 +35,7 @@ const MessageInput = ({ messageConversation, onAddImageClick }: IProps) => {
     }
   };
 
-  if (!messageConversation.conversation_id) return null;
+  if (!messageConversation.id) return null;
 
   return (
     <Paper variant="outlined" sx={{ display: 'flex', alignItems: 'center' }}>

--- a/phone/src/apps/messages/components/form/NewMessageGroupForm.tsx
+++ b/phone/src/apps/messages/components/form/NewMessageGroupForm.tsx
@@ -11,28 +11,13 @@ import { useMessageAPI } from '../../hooks/useMessageAPI';
 const NewMessageGroupForm = ({ phoneNumber }: { phoneNumber?: string }) => {
   const history = useHistory();
   const [t] = useTranslation();
-  const [participant, setParticipant] = useState<any>('');
-  const [participantValue, setParticipantValue] = useState('');
+  const [participants, setParticipants] = useState<any>([]);
   const { getContactByNumber } = useContactActions();
   const contacts = useContactsValue();
   const { addConversation } = useMessageAPI();
 
-  useEffect(() => {
-    if (phoneNumber) {
-      const find = getContactByNumber(phoneNumber);
-      if (find) {
-        setParticipant(find);
-      } else {
-        setParticipantValue(phoneNumber);
-      }
-    }
-  }, [phoneNumber, getContactByNumber]);
-
   const handleSubmit = () => {
-    if (participantValue || participant) {
-      const targetNumber = participant.number ?? participantValue;
-      addConversation(targetNumber);
-    }
+    console.log(participants);
   };
 
   const handleCancel = () => {
@@ -40,39 +25,28 @@ const NewMessageGroupForm = ({ phoneNumber }: { phoneNumber?: string }) => {
   };
 
   const renderAutocompleteInput = (params) => (
-    <TextField
-      {...params}
-      fullWidth
-      label={t('MESSAGES.INPUT_NAME_OR_NUMBER')}
-      onChange={(e) => setParticipant(e.currentTarget.value)}
-    />
+    <TextField {...params} fullWidth label={t('MESSAGES.INPUT_NAME_OR_NUMBER')} />
   );
-
-  const submitDisabled = !participantValue && !participant;
 
   return (
     <Box>
       <Box px={2} py={3}>
         <Autocomplete
-          value={participant}
-          inputValue={participantValue}
           freeSolo
           disablePortal
           PopperComponent={(props) => <Popper placement="bottom-start" {...props} />}
+          multiple
           autoHighlight
           options={contacts}
-          // I am so sorry
           ListboxProps={{ style: { marginLeft: 10 } }}
-          getOptionLabel={(contact) => contact.display || contact.number || participant}
-          onChange={(e, value: any) => setParticipant(value)}
-          onInputChange={(e, value: any) => setParticipantValue(value)}
+          getOptionLabel={(contact) => contact.display || contact.number}
+          onChange={(e, value: any) => setParticipants(value)}
           renderInput={renderAutocompleteInput}
         />
       </Box>
       <Box px={2} py={3}>
         <Button
-          onClick={() => handleSubmit()}
-          disabled={submitDisabled}
+          onClick={handleSubmit}
           variant="contained"
           fullWidth
           sx={{ mb: 1 }}

--- a/phone/src/apps/messages/components/form/NewMessageGroupForm.tsx
+++ b/phone/src/apps/messages/components/form/NewMessageGroupForm.tsx
@@ -8,6 +8,7 @@ import { TextField } from '@ui/components/Input';
 import { useContactsValue } from '../../../contacts/hooks/state';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
 import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
+import { PreDBConversation } from '@typings/messages';
 
 const NewMessageGroupForm = ({ phoneNumber }: { phoneNumber?: string }) => {
   const history = useHistory();
@@ -25,10 +26,13 @@ const NewMessageGroupForm = ({ phoneNumber }: { phoneNumber?: string }) => {
   const handleSubmit = () => {
     const selectedParticipants = participants.map((participant) => participant.number);
 
-    const dto = {
-      conversationLabel: conversationLabel || participants[0],
-      selectedParticipants: [myPhoneNumber, ...selectedParticipants],
+    const dto: PreDBConversation = {
+      conversationLabel: isGroupChat ? conversationLabel : '',
+      participants: [myPhoneNumber, ...selectedParticipants],
+      isGroupChat,
     };
+
+    addConversation(dto);
   };
 
   useEffect(() => {
@@ -73,7 +77,7 @@ const NewMessageGroupForm = ({ phoneNumber }: { phoneNumber?: string }) => {
     />
   );
 
-  const disableSubmit = !participants.length || (isGroupChat && !conversationLabel);
+  const disableSubmit = !participants?.length || (isGroupChat && !conversationLabel);
 
   return (
     <Box>

--- a/phone/src/apps/messages/components/list/MessageGroupItem.tsx
+++ b/phone/src/apps/messages/components/list/MessageGroupItem.tsx
@@ -43,6 +43,23 @@ const MessageGroupItem = ({
     [contacts, getContactByNumber],
   );
 
+  const getLabelOrContact = useCallback(() => {
+    const conversationLabel = messageConversation.label;
+    // This is the source
+    const participant = messageConversation.participant;
+    const conversationList = messageConversation.conversationList.split('+');
+
+    // Label is required if the conversation is a group chat
+    if (messageConversation.isGroupChat) return conversationLabel;
+
+    for (const p of conversationList) {
+      if (p !== participant) {
+        const contact = contactDisplay(p);
+        return contact ? contact.display : p;
+      }
+    }
+  }, [messageConversation, contactDisplay]);
+
   return (
     <ListItem
       key={messageConversation.id}
@@ -58,16 +75,15 @@ const MessageGroupItem = ({
       <ListItemAvatar>
         <Badge
           color="error"
-          badgeContent={messageConversation.unread <= 99 ? messageConversation.unread : '99+'}
-          invisible={messageConversation.unread <= 0}
+          badgeContent={
+            messageConversation.unreadCount <= 99 ? messageConversation.unreadCount : '99+'
+          }
+          invisible={messageConversation.unreadCount <= 0}
         >
-          <MuiAvatar src={contactDisplay(messageConversation.participant)?.avatar} />
+          <MuiAvatar />
         </Badge>
       </ListItemAvatar>
-      <ListItemText sx={{ overflow: 'hidden' }}>
-        {contactDisplay(messageConversation.participant)?.display ||
-          messageConversation.participant}
-      </ListItemText>
+      <ListItemText sx={{ overflow: 'hidden' }}>{getLabelOrContact()}</ListItemText>
     </ListItem>
   );
 };

--- a/phone/src/apps/messages/components/list/MessageGroupItem.tsx
+++ b/phone/src/apps/messages/components/list/MessageGroupItem.tsx
@@ -69,7 +69,11 @@ const MessageGroupItem = ({
     >
       {isEditing && (
         <ListItemIcon>
-          <Checkbox edge="start" disableRipple />
+          <Checkbox
+            checked={checked.indexOf(messageConversation.id) !== -1}
+            edge="start"
+            disableRipple
+          />
         </ListItemIcon>
       )}
       <ListItemAvatar>

--- a/phone/src/apps/messages/components/list/MessageGroupItem.tsx
+++ b/phone/src/apps/messages/components/list/MessageGroupItem.tsx
@@ -18,8 +18,8 @@ interface IProps {
   messageConversation: MessageConversation;
   handleClick: (conversations: MessageConversation) => () => void;
   isEditing: boolean;
-  checked: string[];
-  handleToggle: (id: string) => void;
+  checked: number[];
+  handleToggle: (id: number) => void;
 }
 
 const MessageGroupItem = ({
@@ -30,7 +30,7 @@ const MessageGroupItem = ({
   handleToggle,
 }: IProps): any => {
   const toggleCheckbox = () => {
-    handleToggle(messageConversation.conversation_id);
+    handleToggle(messageConversation.id);
   };
 
   const contacts = useContacts();
@@ -45,18 +45,14 @@ const MessageGroupItem = ({
 
   return (
     <ListItem
-      key={messageConversation.conversation_id}
+      key={messageConversation.id}
       onClick={!isEditing ? handleClick(messageConversation) : toggleCheckbox}
       divider
       button
     >
       {isEditing && (
         <ListItemIcon>
-          <Checkbox
-            edge="start"
-            checked={checked.indexOf(messageConversation.conversation_id) !== -1}
-            disableRipple
-          />
+          <Checkbox edge="start" disableRipple />
         </ListItemIcon>
       )}
       <ListItemAvatar>
@@ -65,12 +61,12 @@ const MessageGroupItem = ({
           badgeContent={messageConversation.unread <= 99 ? messageConversation.unread : '99+'}
           invisible={messageConversation.unread <= 0}
         >
-          <MuiAvatar src={contactDisplay(messageConversation.phoneNumber)?.avatar} />
+          <MuiAvatar src={contactDisplay(messageConversation.participant)?.avatar} />
         </Badge>
       </ListItemAvatar>
       <ListItemText sx={{ overflow: 'hidden' }}>
-        {contactDisplay(messageConversation.phoneNumber)?.display ||
-          messageConversation.phoneNumber}
+        {contactDisplay(messageConversation.participant)?.display ||
+          messageConversation.participant}
       </ListItemText>
     </ListItem>
   );

--- a/phone/src/apps/messages/components/list/MessagesList.tsx
+++ b/phone/src/apps/messages/components/list/MessagesList.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../hooks/state';
 import EditIcon from '@mui/icons-material/Edit';
 import { useMessageActions } from '../../hooks/useMessageActions';
+import { useMessageAPI } from '../../hooks/useMessageAPI';
 
 const MessagesList = (): any => {
   const [isEditing, setIsEditing] = useIsEditing();
@@ -24,7 +25,7 @@ const MessagesList = (): any => {
 
   const { conversations, goToConversation } = useMessages();
 
-  const { setMessageReadState } = useMessageActions();
+  const { setMessageRead } = useMessageAPI();
 
   const filteredConversations = useFilteredConversationsValue();
   const [searchValue, setSearchValue] = useFilterValueState();
@@ -32,7 +33,7 @@ const MessagesList = (): any => {
   if (!conversations) return <p>No messages</p>;
 
   const handleClick = (conversation: MessageConversation) => () => {
-    setMessageReadState(conversation.id, 0);
+    setMessageRead(conversation.id);
     goToConversation(conversation);
   };
 

--- a/phone/src/apps/messages/components/list/MessagesList.tsx
+++ b/phone/src/apps/messages/components/list/MessagesList.tsx
@@ -41,7 +41,7 @@ const MessagesList = (): any => {
   };
 
   const handleToggleConversation = (conversationId: number) => {
-    const currentIndex = checkedConversation.find((c) => c === conversationId);
+    const currentIndex = checkedConversation.indexOf(conversationId);
     const newChecked = [...checkedConversation];
 
     if (currentIndex === -1) {

--- a/phone/src/apps/messages/components/list/MessagesList.tsx
+++ b/phone/src/apps/messages/components/list/MessagesList.tsx
@@ -32,7 +32,7 @@ const MessagesList = (): any => {
   if (!conversations) return <p>No messages</p>;
 
   const handleClick = (conversation: MessageConversation) => () => {
-    setMessageReadState(conversation.conversation_id, 0);
+    setMessageReadState(conversation.id, 0);
     goToConversation(conversation);
   };
 
@@ -40,8 +40,8 @@ const MessagesList = (): any => {
     setIsEditing((prev) => !prev);
   };
 
-  const handleToggleConversation = (conversationId: string) => {
-    const currentIndex = checkedConversation.indexOf(conversationId);
+  const handleToggleConversation = (conversationId: number) => {
+    const currentIndex = checkedConversation.find((c) => c === conversationId);
     const newChecked = [...checkedConversation];
 
     if (currentIndex === -1) {
@@ -81,7 +81,7 @@ const MessagesList = (): any => {
                   handleToggle={handleToggleConversation}
                   isEditing={isEditing}
                   checked={checkedConversation}
-                  key={conversation.conversation_id}
+                  key={conversation.id}
                   messageConversation={conversation}
                   handleClick={handleClick}
                 />

--- a/phone/src/apps/messages/components/modal/Conversation.tsx
+++ b/phone/src/apps/messages/components/modal/Conversation.tsx
@@ -34,7 +34,7 @@ const Conversation: React.FC<IProps> = ({ activeMessageGroup, messages }) => {
   const [hasMore, setHasMore] = useState(!!messages.length);
   const { getContactByNumber } = useContactActions();
 
-  const conversationContact = getContactByNumber(activeMessageGroup.phoneNumber);
+  const conversationContact = getContactByNumber(activeMessageGroup.participant);
 
   const handleNextPage = useCallback(() => {
     fetchNui<ServerPromiseResp<Message[]>>(MessageEvents.FETCH_MESSAGES, {
@@ -106,7 +106,7 @@ const Conversation: React.FC<IProps> = ({ activeMessageGroup, messages }) => {
         </Box>
       </Box>
       <MessageInput
-        messageGroupName={conversationContact?.display || activeMessageGroup.phoneNumber}
+        messageGroupName={activeMessageGroup.participant}
         messageConversation={activeMessageGroup}
         onAddImageClick={() => setContextMenuOpen(true)}
       />

--- a/phone/src/apps/messages/components/modal/Conversation.tsx
+++ b/phone/src/apps/messages/components/modal/Conversation.tsx
@@ -11,7 +11,6 @@ import { useSnackbar } from '@os/snackbar/hooks/useSnackbar';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import InfiniteScroll from 'react-infinite-scroll-component';
-import { useContactActions } from '../../../contacts/hooks/useContactActions';
 import MessageContextMenu from './MessageContextMenu';
 
 interface IProps {
@@ -32,9 +31,6 @@ const Conversation: React.FC<IProps> = ({ activeMessageGroup, messages }) => {
   const [t] = useTranslation();
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(!!messages.length);
-  const { getContactByNumber } = useContactActions();
-
-  const conversationContact = getContactByNumber(activeMessageGroup.participant);
 
   const handleNextPage = useCallback(() => {
     fetchNui<ServerPromiseResp<Message[]>>(MessageEvents.FETCH_MESSAGES, {

--- a/phone/src/apps/messages/components/modal/GroupDetailsModal.tsx
+++ b/phone/src/apps/messages/components/modal/GroupDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React from 'react';
 import Modal from '@ui/components/Modal';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';

--- a/phone/src/apps/messages/components/modal/GroupDetailsModal.tsx
+++ b/phone/src/apps/messages/components/modal/GroupDetailsModal.tsx
@@ -1,0 +1,67 @@
+import React, { memo } from 'react';
+import Modal from '@ui/components/Modal';
+import { Box, Button, Stack, Typography } from '@mui/material';
+import PersonIcon from '@mui/icons-material/Person';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import { findParticipants } from '../../utils/helpers';
+import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
+import { useContactActions } from '../../../contacts/hooks/useContactActions';
+
+interface GroupDetailsModalProps {
+  open: boolean;
+  onClose: () => void;
+  conversationList: string;
+  addContact: (number: any) => void;
+}
+
+const GroupDetailsModal: React.FC<GroupDetailsModalProps> = ({
+  open,
+  onClose,
+  conversationList,
+  addContact,
+}) => {
+  const myPhoneNumber = useMyPhoneNumber();
+  const { getContactByNumber } = useContactActions();
+
+  const participants = findParticipants(conversationList, myPhoneNumber);
+
+  const findContact = (phoneNumber: string) => {
+    return getContactByNumber(phoneNumber);
+  };
+
+  const handleAddContact = (participant: string) => {
+    addContact(participant);
+  };
+
+  return (
+    <Modal visible={open} handleClose={onClose}>
+      <Box>
+        <Stack direction="row" spacing={4}>
+          <Typography fontSize={20}>Details</Typography>
+          {/*<Button size="small">Add participant</Button>*/}
+        </Stack>
+      </Box>
+      {participants.map((participant) => {
+        const contact = findContact(participant);
+
+        return (
+          <Box mt={2}>
+            <Box display="flex" alignItems="center" justifyContent="space-between">
+              <Stack direction="row" spacing={2}>
+                <PersonIcon fontSize="medium" />
+                <Typography fontSize={18}>{contact?.display ?? participant}</Typography>
+              </Stack>
+              {!contact && (
+                <Button onClick={() => handleAddContact(participant)}>
+                  <PersonAddIcon fontSize="medium" />
+                </Button>
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Modal>
+  );
+};
+
+export default GroupDetailsModal;

--- a/phone/src/apps/messages/components/modal/MessageBubble.tsx
+++ b/phone/src/apps/messages/components/modal/MessageBubble.tsx
@@ -100,7 +100,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
                 <>{message.message}</>
               )}
               {isMine && (
-                <IconButton onClick={openMenu}>
+                <IconButton color="primary" onClick={openMenu}>
                   <MoreVertIcon />
                 </IconButton>
               )}

--- a/phone/src/apps/messages/components/modal/MessageBubble.tsx
+++ b/phone/src/apps/messages/components/modal/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Paper } from '@mui/material';
+import { IconButton, Paper, Typography } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { makeStyles } from '@mui/styles';
 import React, { useState } from 'react';
@@ -10,6 +10,7 @@ import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
 import MessageBubbleMenu from './MessageBubbleMenu';
 import { useSetSelectedMessage } from '../../hooks/state';
 import MessageEmbed from '../ui/MessageEmbed';
+import { useContactActions } from '../../../contacts/hooks/useContactActions';
 
 const useStyles = makeStyles((theme) => ({
   mySms: {
@@ -57,6 +58,7 @@ interface MessageBubbleProps {
 export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   const classes = useStyles();
   const [menuOpen, setMenuOpen] = useState(false);
+  const { getDisplayByNumber } = useContactActions();
 
   const setSelectedMessage = useSetSelectedMessage();
   const openMenu = () => {
@@ -70,6 +72,10 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   if (message?.embed) {
     parsedEmbed = JSON.parse(message?.embed);
   }
+
+  const getAuthorDisplay = () => {
+    return getDisplayByNumber(message.author) || message.author;
+  };
 
   return (
     <>
@@ -91,6 +97,11 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
               </IconButton>
             )}
           </StyledMessage>
+        )}
+        {!isMine && (
+          <Typography fontWeight="bold" fontSize={14} color="#232323">
+            {getAuthorDisplay()}
+          </Typography>
         )}
       </Paper>
       <MessageBubbleMenu open={menuOpen} handleClose={() => setMenuOpen(false)} />

--- a/phone/src/apps/messages/components/modal/MessageBubble.tsx
+++ b/phone/src/apps/messages/components/modal/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Paper, Typography } from '@mui/material';
+import { Avatar, Box, IconButton, Paper, Typography } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { makeStyles } from '@mui/styles';
 import React, { useState } from 'react';
@@ -19,23 +19,23 @@ const useStyles = makeStyles((theme) => ({
     padding: '6px 16px',
     height: 'auto',
     width: 'auto',
-    minWidth: '60%',
-    maxWidth: '85%',
-    background: theme.palette.background.default,
-    color: theme.palette.text.primary,
+    minWidth: '50%',
+    maxWidth: '80%',
+    background: theme.palette.primary.light,
+    color: theme.palette.getContrastText(theme.palette.primary.light),
     borderRadius: '20px',
     textOverflow: 'ellipsis',
   },
   sms: {
     float: 'left',
-    margin: theme.spacing(1),
     padding: '6px 12px',
     width: 'auto',
-    minWidth: '60%',
-    maxWidth: '85%',
+    marginLeft: 5,
+    minWidth: '50%',
+    maxWidth: '80%',
     height: 'auto',
-    background: theme.palette.primary.light,
-    color: theme.palette.getContrastText(theme.palette.primary.light),
+    background: theme.palette.background.default,
+    color: theme.palette.text.primary,
     borderRadius: '15px',
     textOverflow: 'ellipsis',
   },
@@ -58,7 +58,7 @@ interface MessageBubbleProps {
 export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   const classes = useStyles();
   const [menuOpen, setMenuOpen] = useState(false);
-  const { getDisplayByNumber } = useContactActions();
+  const { getContactByNumber } = useContactActions();
 
   const setSelectedMessage = useSetSelectedMessage();
   const openMenu = () => {
@@ -73,37 +73,46 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
     parsedEmbed = JSON.parse(message?.embed);
   }
 
-  const getAuthorDisplay = () => {
-    return getDisplayByNumber(message.author) || message.author;
+  const getContact = () => {
+    return getContactByNumber(message.author);
   };
 
   return (
     <>
-      <Paper className={isMine ? classes.mySms : classes.sms} variant="outlined">
-        {message.is_embed ? (
-          <MessageEmbed type={parsedEmbed.type} embed={parsedEmbed} isMine={isMine} />
-        ) : (
-          <StyledMessage>
-            {isImage(message.message) ? (
-              <PictureReveal>
-                <PictureResponsive src={message.message} alt="message multimedia" />
-              </PictureReveal>
-            ) : (
-              <>{message.message}</>
-            )}
-            {isMine && (
-              <IconButton onClick={openMenu}>
-                <MoreVertIcon />
-              </IconButton>
-            )}
-          </StyledMessage>
-        )}
-        {!isMine && (
-          <Typography fontWeight="bold" fontSize={14} color="#232323">
-            {getAuthorDisplay()}
-          </Typography>
-        )}
-      </Paper>
+      <Box
+        display="flex"
+        ml={1}
+        alignItems="stretch"
+        justifyContent={isMine ? 'flex-end' : 'flex-start'}
+        mt={1}
+      >
+        {!isMine ? <Avatar src={getContact().avatar} /> : null}
+        <Paper className={isMine ? classes.mySms : classes.sms} variant="outlined">
+          {message.is_embed ? (
+            <MessageEmbed type={parsedEmbed.type} embed={parsedEmbed} isMine={isMine} />
+          ) : (
+            <StyledMessage>
+              {isImage(message.message) ? (
+                <PictureReveal>
+                  <PictureResponsive src={message.message} alt="message multimedia" />
+                </PictureReveal>
+              ) : (
+                <>{message.message}</>
+              )}
+              {isMine && (
+                <IconButton onClick={openMenu}>
+                  <MoreVertIcon />
+                </IconButton>
+              )}
+            </StyledMessage>
+          )}
+          {!isMine && (
+            <Typography fontWeight="bold" fontSize={14} color="#ddd">
+              {getContact().display ?? message.author}
+            </Typography>
+          )}
+        </Paper>
+      </Box>
       <MessageBubbleMenu open={menuOpen} handleClose={() => setMenuOpen(false)} />
     </>
   );

--- a/phone/src/apps/messages/components/modal/MessageContactModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageContactModal.tsx
@@ -6,6 +6,7 @@ import { useContactsValue } from '../../../contacts/hooks/state';
 import { TextField } from '@ui/components/Input';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
 import { MessageConversation } from '../../../../../../typings/messages';
+import useMessages from '../../hooks/useMessages';
 
 interface MessageContactModalProps {
   isVisible: boolean;
@@ -22,10 +23,12 @@ const MessageContactModal: React.FC<MessageContactModalProps> = ({
   const contacts = useContactsValue();
   const [selectedContact, setSelectContact] = useState(null);
   const { sendEmbedMessage } = useMessageAPI();
+  const { activeMessageConversation } = useMessages();
 
   const handleSendEmbedMessage = () => {
     sendEmbedMessage({
       conversationId: messageGroup.id,
+      conversationList: activeMessageConversation.conversationList,
       embed: { type: 'contact', ...selectedContact },
       tgtPhoneNumber: messageGroup.participant,
     });

--- a/phone/src/apps/messages/components/modal/MessageContactModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageContactModal.tsx
@@ -25,9 +25,9 @@ const MessageContactModal: React.FC<MessageContactModalProps> = ({
 
   const handleSendEmbedMessage = () => {
     sendEmbedMessage({
-      conversationId: messageGroup.conversation_id,
+      conversationId: messageGroup.id,
       embed: { type: 'contact', ...selectedContact },
-      tgtPhoneNumber: messageGroup.phoneNumber,
+      tgtPhoneNumber: messageGroup.participant,
     });
     onClose();
   };

--- a/phone/src/apps/messages/components/modal/MessageContextMenu.tsx
+++ b/phone/src/apps/messages/components/modal/MessageContextMenu.tsx
@@ -2,13 +2,13 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import ContactPageIcon from '@mui/icons-material/ContactPage';
-import { ContextMenu, IContextMenuOption } from '../../../../ui/components/ContextMenu';
+import { ContextMenu, IContextMenuOption } from '@ui/components/ContextMenu';
 import qs from 'qs';
 import { useHistory, useLocation } from 'react-router-dom';
 import { MessageImageModal } from './MessageImageModal';
 import MessageContactModal from './MessageContactModal';
-import Backdrop from '../../../../ui/components/Backdrop';
-import { MessageConversation } from '../../../../../../typings/messages';
+import Backdrop from '@ui/components/Backdrop';
+import { MessageConversation } from '@typings/messages';
 
 interface MessageCtxMenuProps {
   isOpen: boolean;

--- a/phone/src/apps/messages/components/modal/MessageImageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageImageModal.tsx
@@ -6,7 +6,7 @@ import { deleteQueryFromLocation } from '@common/utils/deleteQueryFromLocation';
 import { PictureResponsive } from '@ui/components/PictureResponsive';
 import { useTranslation } from 'react-i18next';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
-import { MessageConversation } from '../../../../../../typings/messages';
+import { MessageConversation } from '@typings/messages';
 import useMessages from '../../hooks/useMessages';
 
 interface IProps {
@@ -44,7 +44,7 @@ export const MessageImageModal = ({
       });
       onClose();
     },
-    [sendMessage, messageGroup, onClose],
+    [sendMessage, messageGroup, onClose, activeMessageConversation],
   );
 
   const sendFromQueryParam = useCallback(

--- a/phone/src/apps/messages/components/modal/MessageImageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageImageModal.tsx
@@ -7,6 +7,7 @@ import { PictureResponsive } from '@ui/components/PictureResponsive';
 import { useTranslation } from 'react-i18next';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
 import { MessageConversation } from '../../../../../../typings/messages';
+import useMessages from '../../hooks/useMessages';
 
 interface IProps {
   messageGroup: MessageConversation | undefined;
@@ -31,11 +32,13 @@ export const MessageImageModal = ({
     setImagePreview(null);
     history.replace(deleteQueryFromLocation({ pathname, search }, 'image'));
   }, [history, pathname, search, setImagePreview]);
+  const { activeMessageConversation } = useMessages();
 
   const sendImageMessage = useCallback(
     (m) => {
       sendMessage({
         conversationId: messageGroup.id,
+        conversationList: activeMessageConversation.conversationList,
         message: m,
         tgtPhoneNumber: messageGroup.participant,
       });

--- a/phone/src/apps/messages/components/modal/MessageImageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageImageModal.tsx
@@ -35,9 +35,9 @@ export const MessageImageModal = ({
   const sendImageMessage = useCallback(
     (m) => {
       sendMessage({
-        conversationId: messageGroup.conversation_id,
+        conversationId: messageGroup.id,
         message: m,
-        tgtPhoneNumber: messageGroup.phoneNumber,
+        tgtPhoneNumber: messageGroup.participant,
       });
       onClose();
     },

--- a/phone/src/apps/messages/components/modal/MessageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageModal.tsx
@@ -109,9 +109,7 @@ export const MessageModal = () => {
     );
 
   // don't allow too many characters, it takes too much room
-  let header =
-    getDisplayByNumber(activeMessageConversation.phoneNumber) ||
-    activeMessageConversation.phoneNumber;
+  let header = activeMessageConversation.label;
   const truncatedHeader = `${header.slice(0, MAX_HEADER_CHARS).trim()}...`;
   header = header.length > MAX_HEADER_CHARS ? truncatedHeader : header;
 
@@ -127,7 +125,7 @@ export const MessageModal = () => {
     return history.push(`/contacts/-1/?addNumber=${number}&referal=${referal}`);
   };
 
-  const targetNumber = activeMessageConversation.phoneNumber;
+  const targetNumber = activeMessageConversation.participant;
 
   return (
     <>

--- a/phone/src/apps/messages/components/modal/MessageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageModal.tsx
@@ -22,6 +22,7 @@ import { makeStyles } from '@mui/styles';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
 import { useCall } from '@os/call/hooks/useCall';
 import { Call } from '@mui/icons-material';
+import { useMessageActions } from '../../hooks/useMessageActions';
 
 const LARGE_HEADER_CHARS = 30;
 const MAX_HEADER_CHARS = 80;
@@ -60,6 +61,7 @@ export const MessageModal = () => {
   const { groupId } = useParams<{ groupId: string }>();
   const { activeMessageConversation, setActiveMessageConversation } = useMessages();
   const { fetchMessages } = useMessageAPI();
+  const { getLabelOrContact } = useMessageActions();
   const { initializeCall } = useCall();
 
   const { getContactByNumber, getDisplayByNumber } = useContactActions();
@@ -101,22 +103,24 @@ export const MessageModal = () => {
   }, [isLoaded]);
 
   // We need to wait for the active conversation to be set.
-  if (!activeMessageConversation)
+  if (!activeMessageConversation) {
     return (
       <div>
         <CircularProgress />
       </div>
     );
+  }
 
+  let header = getLabelOrContact(activeMessageConversation);
   // don't allow too many characters, it takes too much room
-  /*let header = activeMessageConversation.label;
   const truncatedHeader = `${header.slice(0, MAX_HEADER_CHARS).trim()}...`;
   header = header.length > MAX_HEADER_CHARS ? truncatedHeader : header;
 
   const headerClass =
-    header.length > LARGE_HEADER_CHARS ? classes.largeGroupDisplay : classes.groupdisplay;*/
+    header.length > LARGE_HEADER_CHARS ? classes.largeGroupDisplay : classes.groupdisplay;
 
-  const handleAddContact = (number) => {
+  // FIXME: Not sure what this is again...
+  const handleAddContact = (number: any) => {
     const exists = getContactByNumber(number);
     const referal = encodeURIComponent(pathname);
     if (exists) {
@@ -144,9 +148,9 @@ export const MessageModal = () => {
             <Button onClick={closeModal}>
               <ArrowBackIcon fontSize="large" />
             </Button>
-            {/*<Typography variant="h5" className={headerClass}>
+            <Typography variant="h5" className={headerClass}>
               {header}
-            </Typography>*/}
+            </Typography>
             <Tooltip
               classes={{ tooltip: classes.tooltip }}
               title={`${t('GENERIC.CALL')} ${targetNumber}`}

--- a/phone/src/apps/messages/components/modal/MessageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageModal.tsx
@@ -163,7 +163,12 @@ export const MessageModal = () => {
           addContact={handleAddContact}
         />
         {isGroupModalOpen && <Backdrop />}
-        <Box display="flex" justifyContent="space-between" component={Paper}>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          component={Paper}
+          sx={{ borderRadius: 0 }}
+        >
           <Button onClick={closeModal}>
             <ArrowBackIcon fontSize="large" />
           </Button>

--- a/phone/src/apps/messages/components/modal/MessageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageModal.tsx
@@ -102,7 +102,7 @@ export const MessageModal = () => {
 
   useEffect(() => {
     if (!groupId) return;
-    setActiveMessageConversation(groupId);
+    setActiveMessageConversation(parseInt(groupId, 10));
   }, [groupId, setActiveMessageConversation]);
 
   useEffect(() => {

--- a/phone/src/apps/messages/components/modal/MessageModal.tsx
+++ b/phone/src/apps/messages/components/modal/MessageModal.tsx
@@ -109,12 +109,12 @@ export const MessageModal = () => {
     );
 
   // don't allow too many characters, it takes too much room
-  let header = activeMessageConversation.label;
+  /*let header = activeMessageConversation.label;
   const truncatedHeader = `${header.slice(0, MAX_HEADER_CHARS).trim()}...`;
   header = header.length > MAX_HEADER_CHARS ? truncatedHeader : header;
 
   const headerClass =
-    header.length > LARGE_HEADER_CHARS ? classes.largeGroupDisplay : classes.groupdisplay;
+    header.length > LARGE_HEADER_CHARS ? classes.largeGroupDisplay : classes.groupdisplay;*/
 
   const handleAddContact = (number) => {
     const exists = getContactByNumber(number);
@@ -144,9 +144,9 @@ export const MessageModal = () => {
             <Button onClick={closeModal}>
               <ArrowBackIcon fontSize="large" />
             </Button>
-            <Typography variant="h5" className={headerClass}>
+            {/*<Typography variant="h5" className={headerClass}>
               {header}
-            </Typography>
+            </Typography>*/}
             <Tooltip
               classes={{ tooltip: classes.tooltip }}
               title={`${t('GENERIC.CALL')} ${targetNumber}`}

--- a/phone/src/apps/messages/hooks/state.ts
+++ b/phone/src/apps/messages/hooks/state.ts
@@ -46,10 +46,7 @@ export const messageState = {
 
       const regExp = new RegExp(searchValue, 'gi');
 
-      return messageConversations.filter(
-        (conversation) =>
-          conversation?.display?.match(regExp) || conversation.phoneNumber.match(regExp),
-      );
+      return messageConversations.filter((conversation) => conversation.participant.match(regExp));
     },
   }),
   messages: atom<Message[]>({
@@ -80,7 +77,7 @@ export const messageState = {
     key: 'selectedMessage',
     default: null,
   }),
-  checkedConversations: atom<string[]>({
+  checkedConversations: atom<number[]>({
     key: 'checkedConversation',
     default: [],
   }),

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -24,6 +24,7 @@ type UseMessageAPIProps = {
   addConversation: (conversation: PreDBConversation) => void;
   deleteConversation: (conversationIds: number[]) => void;
   fetchMessages: (conversationId: string, page: number) => void;
+  setMessageRead: (conversationId: number) => void;
 };
 
 export const useMessageAPI = (): UseMessageAPIProps => {
@@ -34,6 +35,7 @@ export const useMessageAPI = (): UseMessageAPIProps => {
     deleteLocalMessage,
     updateLocalConversations,
     removeLocalConversation,
+    setMessageReadState,
   } = useMessageActions();
   const history = useHistory();
   const { state: messageConversationsState, contents: messageConversationsContents } =
@@ -85,6 +87,24 @@ export const useMessageAPI = (): UseMessageAPIProps => {
       });
     },
     [t, updateLocalMessages, addAlert, myPhoneNumber],
+  );
+
+  const setMessageRead = useCallback(
+    (conversationId: number) => {
+      fetchNui<ServerPromiseResp<void>>(MessageEvents.SET_MESSAGE_READ, conversationId).then(
+        (resp) => {
+          if (resp.status !== 'ok') {
+            return addAlert({
+              message: 'Failed to read message',
+              type: 'error',
+            });
+          }
+
+          setMessageReadState(conversationId, 0);
+        },
+      );
+    },
+    [addAlert, setMessageReadState],
   );
 
   const deleteMessage = useCallback(
@@ -222,5 +242,6 @@ export const useMessageAPI = (): UseMessageAPIProps => {
     addConversation,
     fetchMessages,
     sendEmbedMessage,
+    setMessageRead,
   };
 };

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -2,7 +2,6 @@ import fetchNui from '@utils/fetchNui';
 import {
   Message,
   MessageConversation,
-  MessageConversationResponse,
   MessageEvents,
   PreDBConversation,
   PreDBMessage,
@@ -17,7 +16,7 @@ import { messageState, useSetMessages } from './state';
 import { useContactActions } from '../../contacts/hooks/useContactActions';
 import { useRecoilValueLoadable } from 'recoil';
 import { MockConversationServerResp } from '../utils/constants';
-import { useMyPhoneNumber } from '../../../os/simcard/hooks/useMyPhoneNumber';
+import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
 
 type UseMessageAPIProps = {
   sendMessage: ({ conversationId, message, tgtPhoneNumber }: PreDBMessage) => void;

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -22,7 +22,7 @@ type UseMessageAPIProps = {
   sendEmbedMessage: ({ conversationId, embed }: PreDBMessage) => void;
   deleteMessage: (message: Message) => void;
   addConversation: (targetNumber: string) => void;
-  deleteConversation: (conversationIds: string[]) => void;
+  deleteConversation: (conversationIds: number[]) => void;
   fetchMessages: (conversationId: string, page: number) => void;
 };
 
@@ -136,16 +136,14 @@ export const useMessageAPI = (): UseMessageAPIProps => {
           });
         }
 
-        const display = getDisplayByNumber(resp.data.phoneNumber);
-        const avatar = getPictureByNumber(resp.data.phoneNumber);
-
+        // FIXME: Fix this
         updateLocalConversations({
-          phoneNumber: resp.data.phoneNumber,
-          conversation_id: resp.data.conversation_id,
+          participant: resp.data.phoneNumber,
+          id: resp.data.conversation_id,
           updatedAt: resp.data.updatedAt,
-          display,
+          conversationList: resp.data.conversationList,
+          label: resp.data.conversationList,
           unread: 0,
-          avatar,
         });
 
         history.push(`/messages/conversations/${resp.data.conversation_id}`);
@@ -164,7 +162,7 @@ export const useMessageAPI = (): UseMessageAPIProps => {
   );
 
   const deleteConversation = useCallback(
-    (conversationIds: string[]) => {
+    (conversationIds: number[]) => {
       fetchNui<ServerPromiseResp<void>>(MessageEvents.DELETE_CONVERSATION, {
         conversationsId: conversationIds,
       }).then((resp) => {

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -13,7 +13,6 @@ import { useMessageActions } from './useMessageActions';
 import { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { messageState, useSetMessages } from './state';
-import { useContactActions } from '../../contacts/hooks/useContactActions';
 import { useRecoilValueLoadable } from 'recoil';
 import { MockConversationServerResp } from '../utils/constants';
 import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
@@ -39,7 +38,6 @@ export const useMessageAPI = (): UseMessageAPIProps => {
   const history = useHistory();
   const { state: messageConversationsState, contents: messageConversationsContents } =
     useRecoilValueLoadable(messageState.messageCoversations);
-  const { getPictureByNumber, getDisplayByNumber } = useContactActions();
   const setMessages = useSetMessages();
 
   const myPhoneNumber = useMyPhoneNumber();
@@ -169,8 +167,6 @@ export const useMessageAPI = (): UseMessageAPIProps => {
       updateLocalConversations,
       addAlert,
       t,
-      getDisplayByNumber,
-      getPictureByNumber,
       messageConversationsContents,
       messageConversationsState,
     ],

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -121,6 +121,14 @@ export const useMessageAPI = (): UseMessageAPIProps => {
       ).then((resp) => {
         if (resp.status !== 'ok') {
           history.push('/messages');
+
+          if (resp.errorMsg === 'MESSAGES.FEEDBACK.MESSAGE_CONVERSATION_DUPLICATE') {
+            return addAlert({
+              message: t('MESSAGES.FEEDBACK.MESSAGE_CONVERSATION_DUPLICATE'),
+              type: 'error',
+            });
+          }
+
           return addAlert({
             message: t('MESSAGE_CONVERSATION_CREATE_ONE_NUMBER_FAILED"', {
               number: conversation.conversationLabel,

--- a/phone/src/apps/messages/hooks/useMessageAPI.ts
+++ b/phone/src/apps/messages/hooks/useMessageAPI.ts
@@ -46,9 +46,10 @@ export const useMessageAPI = (): UseMessageAPIProps => {
   const myPhoneNumber = useMyPhoneNumber();
 
   const sendMessage = useCallback(
-    ({ conversationId, message, tgtPhoneNumber }: PreDBMessage) => {
+    ({ conversationId, message, tgtPhoneNumber, conversationList }: PreDBMessage) => {
       fetchNui<ServerPromiseResp<Message>>(MessageEvents.SEND_MESSAGE, {
         conversationId,
+        conversationList,
         message,
         tgtPhoneNumber,
         sourcePhoneNumber: myPhoneNumber,

--- a/phone/src/apps/messages/hooks/useMessageActions.ts
+++ b/phone/src/apps/messages/hooks/useMessageActions.ts
@@ -5,10 +5,10 @@ import { useRecoilValueLoadable } from 'recoil';
 
 interface MessageActionProps {
   updateLocalConversations: (conversation: MessageConversation) => void;
-  removeLocalConversation: (conversationId: string[]) => void;
+  removeLocalConversation: (conversationId: number[]) => void;
   updateLocalMessages: (messageDto: Message) => void;
   deleteLocalMessage: (messageId: number) => void;
-  setMessageReadState: (conversationId: string, unreadCount: number) => void;
+  setMessageReadState: (conversationId: number, unreadCount: number) => void;
 }
 
 export const useMessageActions = (): MessageActionProps => {
@@ -27,10 +27,10 @@ export const useMessageActions = (): MessageActionProps => {
   );
 
   const setMessageReadState = useCallback(
-    (conversationId: string, unreadCount: number) => {
+    (conversationId: number, unreadCount: number) => {
       setMessageConversation((curVal) =>
         curVal.map((message: MessageConversation) => {
-          if (message.conversation_id === conversationId) {
+          if (message.id === conversationId) {
             return {
               ...message,
               unread: unreadCount,
@@ -45,15 +45,13 @@ export const useMessageActions = (): MessageActionProps => {
   );
 
   const removeLocalConversation = useCallback(
-    (conversationsId: string[]) => {
+    (conversationsId: number[]) => {
       if (conversationLoading !== 'hasValue') return;
 
       if (!conversations.length) return;
 
       setMessageConversation((curVal) =>
-        [...curVal].filter(
-          (conversation) => !conversationsId.includes(conversation.conversation_id),
-        ),
+        [...curVal].filter((conversation) => !conversationsId.includes(conversation.id)),
       );
     },
     [setMessageConversation, conversationLoading, conversations],

--- a/phone/src/apps/messages/hooks/useMessageActions.ts
+++ b/phone/src/apps/messages/hooks/useMessageActions.ts
@@ -82,8 +82,6 @@ export const useMessageActions = (): MessageActionProps => {
 
   const updateLocalMessages = useCallback(
     (messageDto: Message) => {
-      console.log('broadcast messageDTo', messageDto);
-
       if (messageLoading !== 'hasValue') return;
 
       setMessages((currVal) => [

--- a/phone/src/apps/messages/hooks/useMessageActions.ts
+++ b/phone/src/apps/messages/hooks/useMessageActions.ts
@@ -82,6 +82,8 @@ export const useMessageActions = (): MessageActionProps => {
 
   const updateLocalMessages = useCallback(
     (messageDto: Message) => {
+      console.log('broadcast messageDTo', messageDto);
+
       if (messageLoading !== 'hasValue') return;
 
       setMessages((currVal) => [

--- a/phone/src/apps/messages/hooks/useMessageNotifications.ts
+++ b/phone/src/apps/messages/hooks/useMessageNotifications.ts
@@ -19,18 +19,17 @@ export const useMessageNotifications = () => {
   const { getMessageConversationById, goToConversation } = useMessages();
   const { addConversation } = useMessageAPI();
   const activeMessageConversation = useRecoilValue(messageState.activeMessageConversation);
-  const { getDisplayByNumber } = useContactActions();
 
   // Remove notifications from groups when opening them
   history.listen((location) => {
     if (
-      activeMessageConversation?.conversation_id &&
+      activeMessageConversation?.id &&
       matchPath(location.pathname, {
-        path: `/messages/conversations/${activeMessageConversation.conversation_id}`,
+        path: `/messages/conversations/${activeMessageConversation.id}`,
         exact: true,
       })
     ) {
-      removeId(`${NOTIFICATION_ID}:${activeMessageConversation.conversation_id}`);
+      removeId(`${NOTIFICATION_ID}:${activeMessageConversation.id}`);
     }
   });
 
@@ -45,13 +44,12 @@ export const useMessageNotifications = () => {
     }
 
     const id = `${NOTIFICATION_ID}:${conversationId}`;
-    const contactDisplay = getDisplayByNumber(conversationName);
 
     const notification = {
       app: 'MESSAGES',
       id,
       sound: true,
-      title: contactDisplay || group.phoneNumber || conversationName,
+      title: group.participant || conversationName,
       onClick: () => goToConversation(group),
       content: message,
       icon,
@@ -63,7 +61,7 @@ export const useMessageNotifications = () => {
       if (group.unread > 1) {
         addNotification({
           ...n,
-          title: group.phoneNumber || group?.display,
+          title: group.participant,
           content: t('MESSAGES.MESSAGES.UNREAD_MESSAGES', {
             count: group.unread,
           }),

--- a/phone/src/apps/messages/hooks/useMessageNotifications.ts
+++ b/phone/src/apps/messages/hooks/useMessageNotifications.ts
@@ -33,15 +33,10 @@ export const useMessageNotifications = () => {
     }
   });
 
-  const setNotification = ({ conversationName, conversationId, message }) => {
+  const setNotification = ({ conversationId, message }) => {
     let group: MessageConversation = null;
 
     group = getMessageConversationById(conversationId);
-
-    if (!group) {
-      addConversation(conversationName);
-      group = getMessageConversationById(conversationId);
-    }
 
     const id = `${NOTIFICATION_ID}:${conversationId}`;
 
@@ -49,7 +44,7 @@ export const useMessageNotifications = () => {
       app: 'MESSAGES',
       id,
       sound: true,
-      title: group.participant || conversationName,
+      title: group.participant || conversationId.toString(),
       onClick: () => goToConversation(group),
       content: message,
       icon,

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -25,8 +25,6 @@ export const useMessagesService = () => {
   // This is only called for the receiver of the message. We'll be using the standardized pattern for the transmitter.
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
-      console.log('messageDto', messageDto);
-      console.log('acticeMessageConversation', activeMessageConversation);
       if (activeMessageConversation.id !== messageDto.conversation_id) return;
 
       updateLocalMessages(messageDto);

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -30,7 +30,7 @@ export const useMessagesService = () => {
   // This is only called for the receiver of the message. We'll be using the standardized pattern for the transmitter.
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
-      if (activeMessageConversation.conversation_id !== messageDto.conversation_id) return;
+      if (activeMessageConversation.id !== messageDto.conversation_id) return;
 
       updateLocalMessages(messageDto);
     },
@@ -39,16 +39,13 @@ export const useMessagesService = () => {
 
   const handleAddConversation = useCallback(
     (conversation: MessageConversationResponse) => {
-      const display = getDisplayByNumber(conversation.phoneNumber);
-      const avatar = getPictureByNumber(conversation.phoneNumber);
-
       updateLocalConversations({
-        phoneNumber: conversation.phoneNumber,
-        conversation_id: conversation.conversation_id,
+        participant: conversation.phoneNumber,
+        id: conversation.conversation_id,
+        conversationList: conversation.conversationList,
+        label: conversation.label,
         updatedAt: conversation.updatedAt,
-        avatar,
         unread: 0,
-        display,
       });
     },
     [updateLocalConversations, getDisplayByNumber, getPictureByNumber],

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -1,24 +1,16 @@
 import { useActiveMessageConversation } from './state';
 import { useNuiEvent } from 'fivem-nui-react-lib';
-import {
-  Message,
-  MessageConversation,
-  MessageConversationResponse,
-  MessageEvents,
-} from '@typings/messages';
+import { Message, MessageConversation, MessageEvents } from '@typings/messages';
 import { useMessageActions } from './useMessageActions';
 import { useCallback } from 'react';
 import { useMessageNotifications } from './useMessageNotifications';
 import { useLocation } from 'react-router';
-import { usePhoneVisibility } from '@os/phone/hooks/usePhoneVisibility';
-import { useContactActions } from '../../contacts/hooks/useContactActions';
 
 export const useMessagesService = () => {
   const { updateLocalMessages, updateLocalConversations, setMessageReadState } =
     useMessageActions();
   const { setNotification } = useMessageNotifications();
   const { pathname } = useLocation();
-  const { getDisplayByNumber, getPictureByNumber } = useContactActions();
   const activeMessageConversation = useActiveMessageConversation();
 
   const handleMessageBroadcast = ({ conversation_id, message }) => {
@@ -34,7 +26,7 @@ export const useMessagesService = () => {
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
       if (activeMessageConversation.id != messageDto.conversation_id) return;
-      
+
       updateLocalMessages(messageDto);
     },
     [updateLocalMessages, activeMessageConversation],

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -1,6 +1,11 @@
 import { useActiveMessageConversation } from './state';
 import { useNuiEvent } from 'fivem-nui-react-lib';
-import { Message, MessageConversationResponse, MessageEvents } from '@typings/messages';
+import {
+  Message,
+  MessageConversation,
+  MessageConversationResponse,
+  MessageEvents,
+} from '@typings/messages';
 import { useMessageActions } from './useMessageActions';
 import { useCallback } from 'react';
 import { useMessageNotifications } from './useMessageNotifications';
@@ -38,13 +43,13 @@ export const useMessagesService = () => {
   );
 
   const handleAddConversation = useCallback(
-    (conversation: MessageConversationResponse) => {
+    (conversation: MessageConversation) => {
       updateLocalConversations({
-        participant: conversation.phoneNumber,
-        id: conversation.conversation_id,
+        participant: conversation.participant,
+        isGroupChat: conversation.isGroupChat,
+        id: conversation.id,
         conversationList: conversation.conversationList,
         label: conversation.label,
-        updatedAt: conversation.updatedAt,
         unread: 0,
       });
     },

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -34,9 +34,7 @@ export const useMessagesService = () => {
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
       if (activeMessageConversation.id != messageDto.conversation_id) return;
-
-      console.log('updateLocalMessages - updating messages');
-
+      
       updateLocalMessages(messageDto);
     },
     [updateLocalMessages, activeMessageConversation],

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -25,7 +25,9 @@ export const useMessagesService = () => {
   // This is only called for the receiver of the message. We'll be using the standardized pattern for the transmitter.
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
-      if (activeMessageConversation.id != messageDto.conversation_id) return;
+      console.log('messageDto', messageDto);
+      console.log('acticeMessageConversation', activeMessageConversation);
+      if (activeMessageConversation.id !== messageDto.conversation_id) return;
 
       updateLocalMessages(messageDto);
     },

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -18,24 +18,24 @@ export const useMessagesService = () => {
     useMessageActions();
   const { setNotification } = useMessageNotifications();
   const { pathname } = useLocation();
-  const { visibility } = usePhoneVisibility();
   const { getDisplayByNumber, getPictureByNumber } = useContactActions();
   const activeMessageConversation = useActiveMessageConversation();
 
-  const handleMessageBroadcast = ({ conversationName, conversationId, message }) => {
-    if (visibility && pathname.includes(`/messages/conversations/${conversationId}`)) {
+  const handleMessageBroadcast = ({ conversation_id, message }) => {
+    if (pathname.includes(`/messages/conversations/${conversation_id}`)) {
       return;
     }
-
     // Set the current unread count to 1, when they click it will be removed
-    setMessageReadState(conversationId, 1);
-    setNotification({ conversationName, conversationId, message });
+    setMessageReadState(conversation_id, 1);
+    setNotification({ conversationId: conversation_id, message });
   };
 
   // This is only called for the receiver of the message. We'll be using the standardized pattern for the transmitter.
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
-      if (activeMessageConversation.id !== messageDto.conversation_id) return;
+      if (activeMessageConversation.id != messageDto.conversation_id) return;
+
+      console.log('updateLocalMessages - updating messages');
 
       updateLocalMessages(messageDto);
     },
@@ -53,7 +53,7 @@ export const useMessagesService = () => {
         unread: 0,
       });
     },
-    [updateLocalConversations, getDisplayByNumber, getPictureByNumber],
+    [updateLocalConversations],
   );
 
   useNuiEvent('MESSAGES', MessageEvents.CREATE_MESSAGE_BROADCAST, handleMessageBroadcast);

--- a/phone/src/apps/messages/hooks/useMessages.ts
+++ b/phone/src/apps/messages/hooks/useMessages.ts
@@ -10,7 +10,7 @@ interface IUseMessages {
   setActiveMessageConversation: (conversation_id: string) => MessageConversation | null;
   activeMessageConversation: MessageConversation | null;
 
-  goToConversation(g: Pick<MessageConversation, 'id'>): void;
+  goToConversation(g: Pick<MessageConversation, 'conversationList'>): void;
 }
 
 const useMessages = (): IUseMessages => {
@@ -47,11 +47,11 @@ const useMessages = (): IUseMessages => {
   );
 
   const goToConversation = useCallback(
-    (messageGroup) => {
-      if (!messageGroup?.conversation_id || !history) return;
-      setCurrentConversationId(messageGroup.conversation_id);
+    (messageGroup: MessageConversation) => {
+      if (!messageGroup?.id || !history) return;
+      setCurrentConversationId(messageGroup.id);
 
-      history.push(`/messages/conversations/${messageGroup.conversation_id}`);
+      history.push(`/messages/conversations/${messageGroup.id}`);
     },
     [setCurrentConversationId, history],
   );

--- a/phone/src/apps/messages/hooks/useMessages.ts
+++ b/phone/src/apps/messages/hooks/useMessages.ts
@@ -10,7 +10,7 @@ interface IUseMessages {
   setActiveMessageConversation: (conversation_id: string) => MessageConversation | null;
   activeMessageConversation: MessageConversation | null;
 
-  goToConversation(g: Pick<MessageConversation, 'conversation_id'>): void;
+  goToConversation(g: Pick<MessageConversation, 'id'>): void;
 }
 
 const useMessages = (): IUseMessages => {

--- a/phone/src/apps/messages/hooks/useMessages.ts
+++ b/phone/src/apps/messages/hooks/useMessages.ts
@@ -32,8 +32,6 @@ const useMessages = (): IUseMessages => {
 
       if (!contents.length) return;
 
-      console.log('contents from getting convo', contents);
-
       // FIXME: Make sure we have contents as a number as well..
       return contents && contents.find((c) => c.id == id);
     },

--- a/phone/src/apps/messages/hooks/useMessages.ts
+++ b/phone/src/apps/messages/hooks/useMessages.ts
@@ -10,7 +10,7 @@ interface IUseMessages {
   setActiveMessageConversation: (conversation_id: string) => MessageConversation | null;
   activeMessageConversation: MessageConversation | null;
 
-  goToConversation(g: Pick<MessageConversation, 'conversationList'>): void;
+  goToConversation(g: Pick<MessageConversation, 'id'>): void;
 }
 
 const useMessages = (): IUseMessages => {
@@ -32,7 +32,10 @@ const useMessages = (): IUseMessages => {
 
       if (!contents.length) return;
 
-      return contents && contents.find((c) => c.conversation_id === id);
+      console.log('contents from getting convo', contents);
+
+      // FIXME: Make sure we have contents as a number as well..
+      return contents && contents.find((c) => c.id == id);
     },
     [contents, conversationLoading],
   );
@@ -47,11 +50,11 @@ const useMessages = (): IUseMessages => {
   );
 
   const goToConversation = useCallback(
-    (messageGroup: MessageConversation) => {
-      if (!messageGroup?.id || !history) return;
-      setCurrentConversationId(messageGroup.id);
+    (messageConversation: MessageConversation) => {
+      if (!messageConversation?.id || !history) return;
+      setCurrentConversationId(messageConversation.id);
 
-      history.push(`/messages/conversations/${messageGroup.id}`);
+      history.push(`/messages/conversations/${messageConversation.id.toString()}`);
     },
     [setCurrentConversationId, history],
   );

--- a/phone/src/apps/messages/hooks/useMessages.ts
+++ b/phone/src/apps/messages/hooks/useMessages.ts
@@ -6,8 +6,8 @@ import { useHistory } from 'react-router';
 
 interface IUseMessages {
   conversations?: MessageConversation[];
-  getMessageConversationById: (id: string) => MessageConversation | null;
-  setActiveMessageConversation: (conversation_id: string) => MessageConversation | null;
+  getMessageConversationById: (id: number) => MessageConversation | null;
+  setActiveMessageConversation: (conversation_id: number) => MessageConversation | null;
   activeMessageConversation: MessageConversation | null;
 
   goToConversation(g: Pick<MessageConversation, 'id'>): void;
@@ -27,19 +27,19 @@ const useMessages = (): IUseMessages => {
   const _setActiveMessageConversation = useSetRecoilState(messageState.activeMessageConversation);
 
   const getMessageConversationById = useCallback(
-    (id: string): MessageConversation | null => {
+    (id: number): MessageConversation | null => {
       if (conversationLoading !== 'hasValue') return;
 
       if (!contents.length) return;
 
       // FIXME: Make sure we have contents as a number as well..
-      return contents && contents.find((c) => c.id == id);
+      return contents && contents.find((c) => c.id === id);
     },
     [contents, conversationLoading],
   );
 
   const setActiveMessageConversation = useCallback(
-    (groupId: string) => {
+    (groupId: number) => {
       const group = getMessageConversationById(groupId);
       _setActiveMessageConversation(group);
       return group;

--- a/phone/src/apps/messages/utils/constants.ts
+++ b/phone/src/apps/messages/utils/constants.ts
@@ -11,6 +11,15 @@ export const MockMessageConversations: MessageConversation[] = [
     updatedAt: 5,
     isGroupChat: true,
   },
+  {
+    id: 2,
+    conversationList: '111-1134+321+215-8139',
+    participant: '111-1134',
+    unread: 0,
+    label: 'Secret Project Error chat',
+    updatedAt: 5,
+    isGroupChat: true,
+  },
 ];
 
 const MockConversationMessages: Message[] = [

--- a/phone/src/apps/messages/utils/constants.ts
+++ b/phone/src/apps/messages/utils/constants.ts
@@ -15,22 +15,19 @@ export const MockMessageConversations: MessageConversation[] = [
 
 const MockConversationMessages: Message[] = [
   {
-    id: 1,
+    id: 2,
     author: '215-8139',
-    message: '',
-    conversation_id: 1,
+    message: 'Dude, when is this rewrite done?????',
   },
   {
     id: 2,
-    author: '215-8139',
-    message:
-      'Hi asljdf klasdfjkasjdf sdfjf asdf djkjas k kksdfjjsl ks kldfs d fd asd asdfjasdjfjasdkljjfklasjldfjlj asdf sadfdsdkafjkljsdklfjklfjdf',
+    author: '111-1134',
+    message: 'Bro, finish notifications api?????',
   },
   {
     id: 3,
-    author: '215-8139',
-    message: 'Hello',
-    conversation_id: 1,
+    author: '444-4444',
+    message: "Couldn't be me!",
   },
 ];
 

--- a/phone/src/apps/messages/utils/constants.ts
+++ b/phone/src/apps/messages/utils/constants.ts
@@ -3,36 +3,12 @@ import { ServerPromiseResp } from '@typings/common';
 
 export const MockMessageConversations: MessageConversation[] = [
   {
-    conversation_id: '4444+5555',
-    avatar: 'https://i.imgur.com/GCBVgXD.jpeg',
-    phoneNumber: '215-8139',
+    id: 1,
+    conversationList: '123+321',
+    participant: '123',
     unread: 0,
-    display: 'Taso',
+    label: 'Cool thihngs',
     updatedAt: 5,
-  },
-  {
-    conversation_id: '4444+7777',
-    avatar: '',
-    phoneNumber: '603-275-8373',
-    unread: 3,
-    display: 'Chip',
-    updatedAt: 15,
-  },
-  {
-    conversation_id: '3333+5555',
-    avatar: '',
-    phoneNumber: '555-15196',
-    unread: 3,
-    display: 'Rocko',
-    updatedAt: 5,
-  },
-  {
-    conversation_id: '2222+1111',
-    avatar: '',
-    phoneNumber: '444-4444',
-    unread: 3,
-    display: 'Kidz',
-    updatedAt: 7,
   },
 ];
 
@@ -41,7 +17,7 @@ const MockConversationMessages: Message[] = [
     id: 1,
     author: '215-8139',
     message: '',
-    conversation_id: '4444+5555',
+    conversation_id: 1,
   },
   {
     id: 2,
@@ -53,12 +29,7 @@ const MockConversationMessages: Message[] = [
     id: 3,
     author: '215-8139',
     message: 'Hello',
-    conversation_id: '4444+5555',
-  },
-  {
-    id: 5,
-    author: '215-8139',
-    message: 'https://i.tasoagc.dev/LtuA.png',
+    conversation_id: 1,
   },
 ];
 

--- a/phone/src/apps/messages/utils/constants.ts
+++ b/phone/src/apps/messages/utils/constants.ts
@@ -4,12 +4,12 @@ import { ServerPromiseResp } from '@typings/common';
 export const MockMessageConversations: MessageConversation[] = [
   {
     id: 1,
-    conversationList: '123+321',
-    participant: '123',
+    conversationList: '111-1134+321+215-8139',
+    participant: '111-1134',
     unread: 0,
     label: 'Cool thihngs',
     updatedAt: 5,
-    isGroupChat: false,
+    isGroupChat: true,
   },
 ];
 

--- a/phone/src/apps/messages/utils/constants.ts
+++ b/phone/src/apps/messages/utils/constants.ts
@@ -9,6 +9,7 @@ export const MockMessageConversations: MessageConversation[] = [
     unread: 0,
     label: 'Cool thihngs',
     updatedAt: 5,
+    isGroupChat: false,
   },
 ];
 

--- a/phone/src/apps/messages/utils/helpers.ts
+++ b/phone/src/apps/messages/utils/helpers.ts
@@ -1,0 +1,8 @@
+/**
+ * Find all participants except the source;
+ * @param conversationList
+ * @param phoneNumber
+ */
+export const findParticipants = (conversationList: string, phoneNumber: string) => {
+  return conversationList.split('+').filter((participant) => participant !== phoneNumber);
+};

--- a/resources/client/cl_messages.ts
+++ b/resources/client/cl_messages.ts
@@ -13,7 +13,7 @@ RegisterNuiProxy(MessageEvents.FETCH_MESSAGES);
 RegisterNuiProxy(MessageEvents.CREATE_MESSAGE_CONVERSATION);
 RegisterNuiProxy(MessageEvents.DELETE_CONVERSATION);
 RegisterNuiProxy(MessageEvents.SEND_MESSAGE);
-/*RegisterNuiProxy(MessageEvents.SET_MESSAGE_READ);*/
+RegisterNuiProxy(MessageEvents.SET_MESSAGE_READ);
 
 onNet(MessageEvents.SEND_MESSAGE_SUCCESS, (messageDto: PreDBMessage) => {
   sendMessageEvent(MessageEvents.SEND_MESSAGE_SUCCESS, messageDto);

--- a/resources/server/messages/messages.controller.ts
+++ b/resources/server/messages/messages.controller.ts
@@ -92,9 +92,9 @@ onNetPromise<Message, void>(MessageEvents.DELETE_MESSAGE, async (reqObj, resp) =
   });
 });
 
-onNet(MessageEvents.SET_MESSAGE_READ, async (conversationId: number) => {
+onNetPromise<number, void>(MessageEvents.SET_MESSAGE_READ, async (reqObj, resp) => {
   const src = getSource();
-  MessagesService.handleSetMessageRead(src, conversationId).catch((e) =>
+  MessagesService.handleSetMessageRead(reqObj, resp).catch((e) =>
     messagesLogger.error(`Error occurred in set message read event (${src}), Error: ${e.message}`),
   );
 });

--- a/resources/server/messages/messages.controller.ts
+++ b/resources/server/messages/messages.controller.ts
@@ -1,5 +1,6 @@
 import { getSource } from '../utils/miscUtils';
 import {
+  DeleteConversationRequest,
   Message,
   MessageConversation,
   MessageEvents,
@@ -9,6 +10,7 @@ import MessagesService from './messages.service';
 import { messagesLogger } from './messages.utils';
 import { onNetPromise } from '../lib/PromiseNetEvents/onNetPromise';
 import { OnMessageExportMap } from './middleware/onMessage';
+import { Contact } from '../../../typings/contact';
 
 onNetPromise<void, MessageConversation[]>(
   MessageEvents.FETCH_MESSAGE_CONVERSATIONS,
@@ -22,7 +24,7 @@ onNetPromise<void, MessageConversation[]>(
   },
 );
 
-onNetPromise<{ targetNumber: string }, MessageConversation>(
+onNetPromise<string[], MessageConversation>(
   MessageEvents.CREATE_MESSAGE_CONVERSATION,
   async (reqObj, resp) => {
     MessagesService.handleCreateMessageConversation(reqObj, resp).catch((e) => {
@@ -69,7 +71,7 @@ onNetPromise<PreDBMessage, Message>(MessageEvents.SEND_MESSAGE, async (reqObj, r
     });
 });
 
-onNetPromise<{ conversationsId: string[] }, void>(
+onNetPromise<DeleteConversationRequest, void>(
   MessageEvents.DELETE_CONVERSATION,
   async (reqObj, resp) => {
     MessagesService.handleDeleteConversation(reqObj, resp).catch((e) => {
@@ -90,9 +92,9 @@ onNetPromise<Message, void>(MessageEvents.DELETE_MESSAGE, async (reqObj, resp) =
   });
 });
 
-onNet(MessageEvents.SET_MESSAGE_READ, async (groupId: string) => {
+onNet(MessageEvents.SET_MESSAGE_READ, async (conversationId: number) => {
   const src = getSource();
-  MessagesService.handleSetMessageRead(src, groupId).catch((e) =>
+  MessagesService.handleSetMessageRead(src, conversationId).catch((e) =>
     messagesLogger.error(`Error occurred in set message read event (${src}), Error: ${e.message}`),
   );
 });

--- a/resources/server/messages/messages.controller.ts
+++ b/resources/server/messages/messages.controller.ts
@@ -4,13 +4,13 @@ import {
   Message,
   MessageConversation,
   MessageEvents,
+  PreDBConversation,
   PreDBMessage,
 } from '../../../typings/messages';
 import MessagesService from './messages.service';
 import { messagesLogger } from './messages.utils';
 import { onNetPromise } from '../lib/PromiseNetEvents/onNetPromise';
 import { OnMessageExportMap } from './middleware/onMessage';
-import { Contact } from '../../../typings/contact';
 
 onNetPromise<void, MessageConversation[]>(
   MessageEvents.FETCH_MESSAGE_CONVERSATIONS,
@@ -24,7 +24,7 @@ onNetPromise<void, MessageConversation[]>(
   },
 );
 
-onNetPromise<string[], MessageConversation>(
+onNetPromise<PreDBConversation, MessageConversation>(
   MessageEvents.CREATE_MESSAGE_CONVERSATION,
   async (reqObj, resp) => {
     MessagesService.handleCreateMessageConversation(reqObj, resp).catch((e) => {

--- a/resources/server/messages/messages.db.ts
+++ b/resources/server/messages/messages.db.ts
@@ -128,6 +128,18 @@ export class _MessagesDB {
 
     await DbInterface._rawExec(query, [conversationId, phoneNumber]);
   }
+
+  async doesConversationExist(conversationList: string): Promise<boolean> {
+    const query = `SELECT COUNT(*) as count
+                   FROM npwd_messages_conversations
+                   WHERE conversation_list = ?`;
+
+    const [results] = await DbInterface._rawExec(query, conversationList);
+    const result = <any>results;
+    const count = result[0].count;
+
+    return count > 0;
+  }
 }
 
 const MessagesDB = new _MessagesDB();

--- a/resources/server/messages/messages.db.ts
+++ b/resources/server/messages/messages.db.ts
@@ -48,7 +48,11 @@ export class _MessagesDB {
     return <Message[]>results;
   }
 
-  async createConversation(participants: string[], conversationList: string) {
+  async createConversation(
+    participants: string[],
+    conversationList: string,
+    conversationLabel: string,
+  ) {
     const conversationQuery = `INSERT INTO npwd_messages_conversations (conversation_list, label)
                                VALUES (?, ?)`;
     const participantQuery = `INSERT INTO message_participants (converation_id, participant)
@@ -56,7 +60,7 @@ export class _MessagesDB {
 
     const [results] = await DbInterface._rawExec(conversationQuery, [
       conversationList,
-      'static label for now',
+      conversationLabel,
     ]);
     const result = <ResultSetHeader>results;
 
@@ -95,19 +99,27 @@ export class _MessagesDB {
   }
 
   async setMessageRead(conversationId: number, participantNumber: string) {
-    const query = `UPDATE message_participants SET unread_count = 0 WHERE converation_id = ? AND participant = ?`;
+    const query = `UPDATE message_participants
+                   SET unread_count = 0
+                   WHERE converation_id = ?
+                     AND participant = ?`;
 
     await DbInterface._rawExec(query, [conversationId, participantNumber]);
   }
 
   async deleteMessage(message: Message) {
-    const query = `DELETE FROM npwd_messages WHERE id = ?`;
+    const query = `DELETE
+                   FROM npwd_messages
+                   WHERE id = ?`;
 
     await DbInterface._rawExec(query, [message.id]);
   }
 
   async deleteConversation(conversationId: number, phoneNumber: string) {
-    const query = `DELETE FROM message_participants WHERE converation_id = ? AND participant = ?`;
+    const query = `DELETE
+                   FROM message_participants
+                   WHERE converation_id = ?
+                     AND participant = ?`;
 
     await DbInterface._rawExec(query, [conversationId, phoneNumber]);
   }

--- a/resources/server/messages/messages.db.ts
+++ b/resources/server/messages/messages.db.ts
@@ -77,10 +77,7 @@ export class _MessagesDB {
   }
 
   async addParticipantToConversation(conversationList: string, phoneNumber: string) {
-    console.log('trying to get conversationId from list', conversationList);
     const conversationId = await this.getConversationId(conversationList);
-
-    console.log('got convo id', conversationId);
 
     const participantQuery = `INSERT INTO npwd_messages_participants (conversation_id, participant)
                               VALUES (?, ?)`;

--- a/resources/server/messages/messages.db.ts
+++ b/resources/server/messages/messages.db.ts
@@ -38,7 +38,7 @@ export class _MessagesDB {
                           npwd_messages.embed
                    FROM npwd_messages
                    WHERE conversation_id = ?
-                   ORDER BY id DESC
+                   ORDER BY id
                    LIMIT ? OFFSET ?`;
 
     const [results] = await DbInterface._rawExec(query, [
@@ -67,7 +67,7 @@ export class _MessagesDB {
     ]);
     const result = <ResultSetHeader>results;
 
-    let conversationId = result.insertId;
+    const conversationId = result.insertId;
 
     for (const participant of participants) {
       await DbInterface._rawExec(participantQuery, [conversationId, participant]);

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -157,7 +157,7 @@ class _MessagesService {
       });
 
       // participantId is the participants phone number
-      /*for (const participantId of participants) {
+      for (const participantId of participants) {
         if (participantId !== player.getPhoneNumber()) {
           const participantIdentifier = await PlayerService.getIdentifierByPhoneNumber(
             participantId,
@@ -183,7 +183,7 @@ class _MessagesService {
             });
           }
         }
-      }*/
+      }
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -119,8 +119,8 @@ class _MessagesService {
     const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
     const conversationId = reqObj.data.conversationId;
 
-    await this.messagesDB.deleteConversation(conversationId, phoneNumber);
     try {
+      await this.messagesDB.deleteConversation(conversationId, phoneNumber);
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }
@@ -173,10 +173,13 @@ class _MessagesService {
           await this.messagesDB.setMessageUnread(messageData.conversationId, participantNumber);
 
           if (participantPlayer) {
-            emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, participantPlayer.source, messageData);
+            emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, participantPlayer.source, {
+              ...messageData,
+              conversation_id: messageData.conversationId,
+            });
             emitNet(MessageEvents.CREATE_MESSAGE_BROADCAST, participantPlayer.source, {
               conversationName: player.getPhoneNumber(),
-              conversationId: messageData.conversationId,
+              conversation_id: messageData.conversationId,
               message: messageData.message,
               is_embed: messageData.is_embed,
               embed: messageData.embed,

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -176,6 +176,7 @@ class _MessagesService {
             emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, participantPlayer.source, {
               ...messageData,
               conversation_id: messageData.conversationId,
+              author: authorPhoneNumber,
             });
             emitNet(MessageEvents.CREATE_MESSAGE_BROADCAST, participantPlayer.source, {
               conversationName: player.getPhoneNumber(),

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -40,19 +40,6 @@ class _MessagesService {
     }
   }
 
-  async handleFetchMessages(
-    reqObj: PromiseRequest<MessagesRequest>,
-    resp: PromiseEventResp<Message[]>,
-  ) {
-    try {
-      const messages = await MessagesDB.getMessages(reqObj.data);
-
-      resp({ status: 'ok', data: messages });
-    } catch (err) {
-      resp({ status: 'error', errorMsg: err.message });
-    }
-  }
-
   async handleCreateMessageConversation(
     reqObj: PromiseRequest<PreDBConversation>,
     resp: PromiseEventResp<MessageConversation>,
@@ -112,15 +99,14 @@ class _MessagesService {
     }
   }
 
-  async handleDeleteConversation(
-    reqObj: PromiseRequest<DeleteConversationRequest>,
-    resp: PromiseEventResp<void>,
+  async handleFetchMessages(
+    reqObj: PromiseRequest<MessagesRequest>,
+    resp: PromiseEventResp<Message[]>,
   ) {
-    const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
-    const conversationId = reqObj.data.conversationId;
-
     try {
-      await this.messagesDB.deleteConversation(conversationId, phoneNumber);
+      const messages = await MessagesDB.getMessages(reqObj.data);
+
+      resp({ status: 'ok', data: messages });
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }
@@ -208,6 +194,20 @@ class _MessagesService {
       await this.messagesDB.deleteMessage(reqObj.data);
 
       resp({ status: 'ok' });
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
+    }
+  }
+
+  async handleDeleteConversation(
+    reqObj: PromiseRequest<DeleteConversationRequest>,
+    resp: PromiseEventResp<void>,
+  ) {
+    const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
+    const conversationId = reqObj.data.conversationId;
+
+    try {
+      await this.messagesDB.deleteConversation(conversationId, phoneNumber);
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -157,7 +157,7 @@ class _MessagesService {
       });
 
       // participantId is the participants phone number
-      for (const participantId of participants) {
+      /*for (const participantId of participants) {
         if (participantId !== player.getPhoneNumber()) {
           const participantIdentifier = await PlayerService.getIdentifierByPhoneNumber(
             participantId,
@@ -183,7 +183,7 @@ class _MessagesService {
             });
           }
         }
-      }
+      }*/
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -53,26 +53,21 @@ class _MessagesService {
     const doesExist = await this.messagesDB.doesConversationExist(conversationList);
 
     if (doesExist) {
-      console.log('conversation exists');
       const playerHasConversation = await this.messagesDB.doesConversationExistForPlayer(
         conversationList,
         playerPhoneNumber,
       );
 
       if (playerHasConversation) {
-        console.log('playerHasConversation', playerHasConversation);
         return resp({
           status: 'error',
           errorMsg: 'MESSAGES.FEEDBACK.MESSAGE_CONVERSATION_DUPLICATE',
         });
       } else {
-        console.log('trying to add participant');
         const conversationId = await this.messagesDB.addParticipantToConversation(
           conversationList,
           playerPhoneNumber,
         );
-
-        console.log('creating resp data', conversationId);
 
         const respData = {
           id: conversationId,
@@ -230,10 +225,10 @@ class _MessagesService {
     resp: PromiseEventResp<void>,
   ) {
     const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
-    const conversationId = reqObj.data.conversationId;
+    const conversationsId = reqObj.data.conversationsId;
 
     try {
-      for (const id of conversationId) {
+      for (const id of conversationsId) {
         await this.messagesDB.deleteConversation(id, phoneNumber);
       }
       resp({ status: 'ok' });

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -1,18 +1,19 @@
-import PlayerService from '../players/player.service';
-import {
-  Message,
-  MessageConversationResponse,
-  MessageEvents,
-  PreDBMessage,
-} from '../../../typings/messages';
 import MessagesDB, { _MessagesDB } from './messages.db';
 import {
-  createMessageGroupsFromPhoneNumber,
-  getFormattedMessageConversations,
+  createGroupHashID,
   getIdentifiersFromParticipants,
   messagesLogger,
 } from './messages.utils';
 import { PromiseEventResp, PromiseRequest } from '../lib/PromiseNetEvents/promise.types';
+import {
+  DeleteConversationRequest,
+  Message,
+  MessageConversation,
+  MessageEvents,
+  MessagesRequest,
+  PreDBMessage,
+} from '../../../typings/messages';
+import PlayerService from '../players/player.service';
 
 class _MessagesService {
   private readonly messagesDB: _MessagesDB;
@@ -22,88 +23,61 @@ class _MessagesService {
     messagesLogger.debug('Messages service started');
   }
 
-  async handleFetchMessageConversations(reqObj: PromiseRequest, resp: PromiseEventResp<any>) {
-    try {
-      const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
-      const messageConversations = await getFormattedMessageConversations(phoneNumber);
-
-      resp({ status: 'ok', data: messageConversations });
-    } catch (e) {
-      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
-      messagesLogger.error(`Failed to fetch messages groups, ${e.message}`);
-    }
-  }
-
-  async handleCreateMessageConversation(
-    reqObj: PromiseRequest<{ targetNumber: string }>,
-    resp: PromiseEventResp<MessageConversationResponse>,
+  async handleFetchMessageConversations(
+    reqObj: PromiseRequest<void>,
+    resp: PromiseEventResp<MessageConversation[]>,
   ) {
+    const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
+
     try {
-      const sourcePlayer = PlayerService.getPlayer(reqObj.source);
+      const conversations = await MessagesDB.getConversations(phoneNumber);
 
-      const result = await createMessageGroupsFromPhoneNumber(
-        sourcePlayer.getPhoneNumber(),
-        reqObj.data.targetNumber,
-      );
-
-      if (result.error) {
-        return resp({ status: 'error' });
-      }
-
-      if (!result.doesExist) {
-        try {
-          const participant = PlayerService.getPlayerFromIdentifier(result.participant);
-
-          if (participant) {
-            emitNet(MessageEvents.CREATE_MESSAGE_CONVERSATION_SUCCESS, participant.source, {
-              conversation_id: result.conversationId,
-              phoneNumber: sourcePlayer.getPhoneNumber(),
-            });
-          }
-        } catch (e) {
-          resp({ status: 'error', errorMsg: e.message });
-          messagesLogger.error(e.message);
-        }
-      }
-
-      resp({
-        status: 'ok',
-        data: {
-          conversation_id: result.conversationId,
-          phoneNumber: result.phoneNumber,
-          updatedAt: Date.now(),
-        },
-      });
-    } catch (e) {
-      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
-
-      messagesLogger.error(`Failed to create message group, ${e.message}`, {
-        source: reqObj.source,
-        e,
-      });
+      resp({ status: 'ok', data: conversations });
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
     }
   }
 
   async handleFetchMessages(
-    reqObj: PromiseRequest<{ conversationId: string; page: number }>,
+    reqObj: PromiseRequest<MessagesRequest>,
     resp: PromiseEventResp<Message[]>,
   ) {
     try {
-      const messages = await this.messagesDB.getMessages(
-        reqObj.data.conversationId,
-        reqObj.data.page,
-      );
-
-      await this.handleSetMessageRead(reqObj.source, reqObj.data.conversationId);
-
-      messages.sort((a, b) => a.id - b.id);
+      const messages = await MessagesDB.getMessages(reqObj.data);
 
       resp({ status: 'ok', data: messages });
-    } catch (e) {
-      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
-      messagesLogger.error(`Failed to fetch messages, ${e.message}`, {
-        source: reqObj.source,
-      });
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
+    }
+  }
+
+  async handleCreateMessageConversation(
+    reqObj: PromiseRequest<string[]>,
+    resp: PromiseEventResp<any>,
+  ) {
+    const sourcePhoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
+
+    const participants = reqObj.data;
+    const conversationList = createGroupHashID(participants);
+
+    try {
+      await MessagesDB.createConversation([...participants, sourcePhoneNumber], conversationList);
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
+    }
+  }
+
+  async handleDeleteConversation(
+    reqObj: PromiseRequest<DeleteConversationRequest>,
+    resp: PromiseEventResp<void>,
+  ) {
+    const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
+    const conversationId = reqObj.data.conversationId;
+
+    await this.messagesDB.deleteConversation(conversationId, phoneNumber);
+    try {
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
     }
   }
 
@@ -112,22 +86,17 @@ class _MessagesService {
       const player = PlayerService.getPlayer(reqObj.source);
       const authorPhoneNumber = player.getPhoneNumber();
       const messageData = reqObj.data;
-      const participants = getIdentifiersFromParticipants(messageData.conversationId);
+      const participants = getIdentifiersFromParticipants(messageData.conversationList);
       const userIdentifier = player.getIdentifier();
 
-      const messageId = await this.messagesDB.createMessage(
+      const messageId = await this.messagesDB.createMessage({
         userIdentifier,
         authorPhoneNumber,
-        messageData.conversationId,
-        messageData.message,
-        messageData.is_embed,
-        messageData.embed,
-      );
-
-      await this.messagesDB.setMessageUnread(
-        messageData.conversationId,
-        messageData.tgtPhoneNumber,
-      );
+        conversationId: messageData.conversationId,
+        message: messageData.message,
+        is_embed: messageData.is_embed,
+        embed: messageData.embed,
+      });
 
       resp({
         status: 'ok',
@@ -149,8 +118,14 @@ class _MessagesService {
             participantId,
             true,
           );
+          
+          const participantNumber = await PlayerService.getPhoneNumberFromIdentifier(
+            participantIdentifier,
+          );
 
           const participantPlayer = PlayerService.getPlayerFromIdentifier(participantIdentifier);
+
+          await this.messagesDB.setMessageUnread(messageData.conversationId, participantNumber);
 
           if (participantPlayer) {
             emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, participantPlayer.source, messageData);
@@ -164,72 +139,28 @@ class _MessagesService {
           }
         }
       }
-    } catch (e) {
-      resp({ status: 'error', errorMsg: e.message });
-      messagesLogger.error(`Failed to send message, ${e.message}`, {
-        source: reqObj.source,
-      });
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
     }
   }
 
-  // I didn't bother creating a new interface. Will do it soonTM.
-  async handleOnMessageSendResponse(reqObj: any) {
-    const messageData = reqObj.data;
+  async handleSetMessageRead(src: number, conversationId: number) {
+    const phoneNumber = PlayerService.getPlayer(src).getPhoneNumber();
 
-    const messageId = await this.messagesDB.createMessage(
-      messageData.author,
-      messageData.author,
-      messageData.conversation_id,
-      messageData.message,
-    );
-
-    const respData = {
-      ...messageData,
-      id: messageId,
-    };
-
-    emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, reqObj.source, respData);
-  }
-
-  async handleSetMessageRead(src: number, groupId: string) {
     try {
-      const identifier = PlayerService.getPlayer(src).getPhoneNumber();
-      await this.messagesDB.setMessageRead(groupId, identifier);
-    } catch (e) {
-      messagesLogger.error(`Failed to set message as read, ${e.message}`, {
-        source: src,
-      });
-    }
-  }
-
-  async handleDeleteConversation(
-    reqObj: PromiseRequest<{ conversationsId: string[] }>,
-    resp: PromiseEventResp<void>,
-  ) {
-    try {
-      const sourcePhoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
-
-      for (const id of reqObj.data.conversationsId) {
-        await this.messagesDB.deleteConversation(id, sourcePhoneNumber);
-      }
-      resp({ status: 'ok' });
-    } catch (e) {
-      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
-      messagesLogger.error(`Failed to delete conversation, ${e.message}`, {
-        source: reqObj.source,
-      });
+      await this.messagesDB.setMessageRead(conversationId, phoneNumber);
+    } catch (err) {
+      messagesLogger.error(`Failed to read message. Error: ${err.message}`);
     }
   }
 
   async handleDeleteMessage(reqObj: PromiseRequest<Message>, resp: PromiseEventResp<void>) {
     try {
       await this.messagesDB.deleteMessage(reqObj.data);
+
       resp({ status: 'ok' });
-    } catch (e) {
-      resp({ status: 'error', errorMsg: 'GENERIC_DB_ERROR' });
-      messagesLogger.error(`Failed to delete message, ${e.message}`, {
-        source: reqObj.source,
-      });
+    } catch (err) {
+      resp({ status: 'error', errorMsg: err.message });
     }
   }
 }

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -183,7 +183,7 @@ class _MessagesService {
           if (participantPlayer) {
             emitNet(MessageEvents.SEND_MESSAGE_SUCCESS, participantPlayer.source, {
               ...messageData,
-              conversation_id: messageData.conversationId.toString(),
+              conversation_id: messageData.conversationId,
               author: authorPhoneNumber,
             });
             emitNet(MessageEvents.CREATE_MESSAGE_BROADCAST, participantPlayer.source, {
@@ -201,13 +201,16 @@ class _MessagesService {
     }
   }
 
-  async handleSetMessageRead(src: number, conversationId: number) {
-    const phoneNumber = PlayerService.getPlayer(src).getPhoneNumber();
+  async handleSetMessageRead(reqObj: PromiseRequest<number>, resp: PromiseEventResp<void>) {
+    const phoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
 
     try {
-      await this.messagesDB.setMessageRead(conversationId, phoneNumber);
+      await this.messagesDB.setMessageRead(reqObj.data, phoneNumber);
+
+      resp({ status: 'ok' });
     } catch (err) {
       messagesLogger.error(`Failed to read message. Error: ${err.message}`);
+      resp({ status: 'error' });
     }
   }
 
@@ -239,7 +242,6 @@ class _MessagesService {
   }
 
   // Exports
-
   async handleEmitMessage(dto: EmitMessageExportCtx) {
     const { senderNumber, targetNumber, message } = dto;
 

--- a/resources/server/messages/messages.service.ts
+++ b/resources/server/messages/messages.service.ts
@@ -11,6 +11,7 @@ import {
   MessageConversation,
   MessageEvents,
   MessagesRequest,
+  PreDBConversation,
   PreDBMessage,
 } from '../../../typings/messages';
 import PlayerService from '../players/player.service';
@@ -52,16 +53,20 @@ class _MessagesService {
   }
 
   async handleCreateMessageConversation(
-    reqObj: PromiseRequest<string[]>,
-    resp: PromiseEventResp<any>,
+    reqObj: PromiseRequest<PreDBConversation>,
+    resp: PromiseEventResp<MessageConversation>,
   ) {
-    const sourcePhoneNumber = PlayerService.getPlayer(reqObj.source).getPhoneNumber();
+    const conversation = reqObj.data;
+    const participants = conversation.participants;
 
-    const participants = reqObj.data;
     const conversationList = createGroupHashID(participants);
 
     try {
-      await MessagesDB.createConversation([...participants, sourcePhoneNumber], conversationList);
+      await MessagesDB.createConversation(
+        participants,
+        conversationList,
+        conversation.conversationLabel,
+      );
     } catch (err) {
       resp({ status: 'error', errorMsg: err.message });
     }

--- a/resources/server/messages/messages.utils.ts
+++ b/resources/server/messages/messages.utils.ts
@@ -1,62 +1,7 @@
-import { CreateMessageGroupResult, MessageConversation } from '../../../typings/messages';
 import { mainLogger } from '../sv_logger';
-import MessagesDB from './messages.db';
-import PlayerService from '../players/player.service';
 
 export const messagesLogger = mainLogger.child({ module: 'messages' });
 
-// Functions
-export async function getConsolidatedMessageGroups(identifier: string): Promise<any> {
-  const messageConversations = await MessagesDB.getMessageConversations(identifier);
-  return messageConversations.reduce((mapping: any, conversation: any) => {
-    const groupId = conversation.conversation_id;
-
-    if (conversation.participant_identifier != identifier) {
-      mapping[groupId] = {
-        unread: conversation.unreadCount,
-        phoneNumber: conversation.phone_number || conversation.participant_identifier,
-        display: conversation.display,
-        conversation_id: conversation.conversation_id,
-        user_identifier: identifier,
-        updatedAt: Date.parse(conversation.updatedAt),
-      };
-    }
-
-    return mapping;
-  }, {});
-}
-
-export async function getFormattedMessageConversations(
-  identifier: string,
-): Promise<MessageConversation[]> {
-  const conversationMapping = await getConsolidatedMessageGroups(identifier);
-  const conversationIds = await getGroupIds(identifier, conversationMapping);
-
-  return conversationIds.map((conversationId) => {
-    const conversation = conversationMapping[conversationId];
-
-    return {
-      ...conversation,
-    };
-  });
-}
-
-export async function getGroupIds(userIdentifier: string, groupMapping: any): Promise<string[]> {
-  const groupIds: string[] = [];
-  for (const groupId of Object.keys(groupMapping)) {
-    const isMine = (groupMapping[groupId].user_identifier = userIdentifier);
-    if (isMine) {
-      groupIds.push(groupId);
-    }
-  }
-  return groupIds;
-}
-
-/**
- * Create the same unique ID from an identifiers array.
- * They will be always be sorted to ensure always the same ID.
- * @param participants array of player identifiers
- */
 export function createGroupHashID(participants: string[]) {
   // make sure we are always in a consistent order. It is very important
   // that this not change! Changing this order can result in the ability
@@ -69,68 +14,6 @@ export function createGroupHashID(participants: string[]) {
   // we are trying to create a duplicate message group!
 }
 
-/**
- * Main method to handle creation of new message groups. First
- * we retrieve identifiers for each submitted phone number and
- * then rows in npwd_messages_groups are created for each of them
- * bound to a unique groupId. The groupId is any unique string - we
- * use hashes here.
- *
- * These queries are batched with a transaction so that if any of
- * them fail the queries are not committed to the database. This helps
- * avoid situations where some participants get added to the group but
- * one fails resulting in a partial group which would be very confusing
- * to the player.
- * @param sourcePhoneNumber - user who is creating the group
- * @param tgtPhoneNumber - list of phone numbers to add to the grup
- */
-export async function createMessageGroupsFromPhoneNumber(
-  sourcePhoneNumber: string,
-  tgtPhoneNumber: string,
-): Promise<CreateMessageGroupResult> {
-  // we check that each phoneNumber exists before we create the group
-
-  const tgtIdentifier = await PlayerService.getIdentifierFromPhoneNumber(tgtPhoneNumber, true);
-
-  if (!tgtIdentifier) {
-    messagesLogger.error(
-      "Didn't find a identifier for the phone number, this is probably some service number.",
-    );
-  }
-
-  const conversationId = createGroupHashID([sourcePhoneNumber, tgtPhoneNumber]);
-  const existingConversation = await MessagesDB.doesConversationExist(
-    conversationId,
-    tgtPhoneNumber,
-  );
-
-  if (existingConversation) {
-    await MessagesDB.createMessageGroup(
-      existingConversation.user_identifier,
-      conversationId,
-      sourcePhoneNumber,
-    );
-  } else {
-    await MessagesDB.createMessageGroup(sourcePhoneNumber, conversationId, sourcePhoneNumber);
-    await MessagesDB.createMessageGroup(sourcePhoneNumber, conversationId, tgtPhoneNumber);
-  }
-
-  // wrap this in a transaction to make sure ALL of these INSERTs succeed
-  // so we are not left in a situation where only some of the member of the
-  // group exist while other are left off.
-
-  return {
-    error: false,
-    doesExist: existingConversation,
-    conversationId,
-    identifiers: [sourcePhoneNumber, tgtPhoneNumber],
-    phoneNumber: tgtPhoneNumber,
-    participant: tgtIdentifier || tgtPhoneNumber,
-  };
-}
-
-// getting the participants from groupId.
-// this should return the source or and array of identifiers
 export function getIdentifiersFromParticipants(conversationId: string) {
   return conversationId.split('+');
 }

--- a/resources/server/messages/middleware/emitMessage.ts
+++ b/resources/server/messages/middleware/emitMessage.ts
@@ -1,0 +1,9 @@
+import { EmitMessageExportCtx } from '../../../../typings/messages';
+import MessagesService from '../messages.service';
+
+const exp = global.exports;
+
+// I am so tired when I am writing this
+exp('emitMessage', async ({ senderNumber, targetNumber, message }: EmitMessageExportCtx) => {
+  await MessagesService.handleEmitMessage({ senderNumber, targetNumber, message });
+});

--- a/resources/server/messages/middleware/onMessage.ts
+++ b/resources/server/messages/middleware/onMessage.ts
@@ -1,5 +1,4 @@
 import { OnMessageExportCtx } from '../../../../typings/messages';
-import MessagesService from '../messages.service';
 
 const exp = global.exports;
 
@@ -8,16 +7,3 @@ export const OnMessageExportMap = new Map();
 exp('onMessage', (phoneNumber: string, cb: (messageCtx: OnMessageExportCtx) => void) => {
   OnMessageExportMap.set(phoneNumber, cb);
 });
-
-export const onMessageRespond = async (ctx: OnMessageExportCtx, message: string) => {
-  const responseData = {
-    source: ctx.source,
-    data: {
-      message,
-      conversation_id: ctx.data.conversationId,
-      author: ctx.data.tgtPhoneNumber,
-      embed: false,
-      is_embed: false,
-    },
-  };
-};

--- a/resources/server/messages/middleware/onMessage.ts
+++ b/resources/server/messages/middleware/onMessage.ts
@@ -20,6 +20,4 @@ export const onMessageRespond = async (ctx: OnMessageExportCtx, message: string)
       is_embed: false,
     },
   };
-
-  await MessagesService.handleOnMessageSendResponse(responseData);
 };

--- a/resources/server/players/player.db.ts
+++ b/resources/server/players/player.db.ts
@@ -8,6 +8,13 @@ export class PlayerRepo {
     // Get identifier from results
     return (results as any[])[0][config.database.identifierColumn] || null;
   }
+
+  async fetchPhoneNumberFromIdentifier(identifier: string) {
+    const query = `SELECT ${config.database.phoneNumberColumn} FROM ${config.database.playerTable} WHERE ${config.database.identifierColumn} = ?`;
+
+    const [results] = await DbInterface._rawExec(query, [identifier]);
+    return (results as any[])[0][config.database.phoneNumberColumn] || null;
+  }
 }
 
 export default new PlayerRepo();

--- a/resources/server/players/player.service.ts
+++ b/resources/server/players/player.service.ts
@@ -215,6 +215,10 @@ class _PlayerService {
     }
   }
 
+  async getPhoneNumberFromIdentifier(identifier: string) {
+    return await this.playerDB.fetchPhoneNumberFromIdentifier(identifier);
+  }
+
   /**
    * Clear all data from the database we don't want to stored after the player as disconnected.
    */

--- a/resources/server/server.ts
+++ b/resources/server/server.ts
@@ -16,6 +16,7 @@ import './match/match.controller';
 
 // setup exports
 import './bridge/sv_exports';
+import './messages/middleware/emitMessage';
 
 import { mainLogger } from './sv_logger';
 import * as Sentry from '@sentry/node';

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -49,7 +49,7 @@ export interface MessagesRequest {
 }
 
 export interface DeleteConversationRequest {
-  conversationId: number;
+  conversationId: number[];
 }
 
 /**

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -35,6 +35,11 @@ export interface MessageConversation {
   updatedAt: number;
 }
 
+export interface PreDBConversation {
+  participants: string[];
+  conversationLabel: string;
+}
+
 export interface MessagesRequest {
   conversationId: string;
   page: number;

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -30,14 +30,17 @@ export interface MessageConversation {
   id: number;
   conversationList: string;
   label: string;
-  participant: string;
-  unread: number;
-  updatedAt: number;
+  participant?: string;
+  isGroupChat: boolean;
+  unread?: number;
+  unreadCount?: number;
+  updatedAt?: number;
 }
 
 export interface PreDBConversation {
   participants: string[];
   conversationLabel: string;
+  isGroupChat: boolean;
 }
 
 export interface MessagesRequest {

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -49,7 +49,7 @@ export interface MessagesRequest {
 }
 
 export interface DeleteConversationRequest {
-  conversationId: number[];
+  conversationsId: number[];
 }
 
 /**

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -1,14 +1,15 @@
 export interface Message {
   id: number;
   message: string;
-  conversation_id?: string;
+  conversation_id?: number;
   author: string;
   is_embed?: boolean;
   embed?: any;
 }
 
 export interface PreDBMessage {
-  conversationId: string;
+  conversationId: number;
+  conversationList: string;
   tgtPhoneNumber: string;
   sourcePhoneNumber?: string;
   message?: string;
@@ -16,18 +17,31 @@ export interface PreDBMessage {
   embed?: any;
 }
 
-export interface MessageConversation {
-  conversation_id: string;
-  avatar: string;
-  display: string;
-  phoneNumber: string;
-  updatedAt: number;
-  unread: number;
+export interface CreateMessageDTO {
+  userIdentifier: string;
+  authorPhoneNumber: string;
+  conversationId: number;
+  message: string;
+  is_embed: boolean;
+  embed: any;
 }
 
-export interface FormattedMessageConversation {
-  conversation_id: string;
-  phoneNumber: string;
+export interface MessageConversation {
+  id: number;
+  conversationList: string;
+  label: string;
+  participant: string;
+  unread: number;
+  updatedAt: number;
+}
+
+export interface MessagesRequest {
+  conversationId: string;
+  page: number;
+}
+
+export interface DeleteConversationRequest {
+  conversationId: number;
 }
 
 /**
@@ -83,9 +97,11 @@ export interface SetMessageRead {
 }
 
 export interface MessageConversationResponse {
-  conversation_id: string;
+  conversation_id: number;
   phoneNumber: string;
   updatedAt: number;
+  conversationList: string;
+  label: string;
 }
 
 export interface OnMessageExportCtx {

--- a/typings/messages.ts
+++ b/typings/messages.ts
@@ -127,6 +127,12 @@ export interface OnMessageExportCtx {
   respond: (ctx: any, message: string) => void;
 }
 
+export interface EmitMessageExportCtx {
+  senderNumber: string;
+  targetNumber: string;
+  message: string;
+}
+
 export enum MessageEvents {
   FETCH_MESSAGE_CONVERSATIONS = 'npwd:fetchMessageGroups',
   FETCH_MESSAGE_GROUPS_SUCCESS = 'npwd:fetchMessageGroupsSuccess',


### PR DESCRIPTION
Rewriting messages, *again*, sigh.

This time with group chats, and some improvments.

- [x] Relational data
- [x] Group chat
- [x] Notifications
- [x] Restoring conversations
- [x] UI improvments

Please feel free to test this branch out.

Here's some ideas, and concepts.

The proposal for storing each `user_identifier` in separate row, comes from Avarians PR proposal https://github.com/project-error/npwd/pull/531/commits/8ad1089cb0acfe55a130e3307e2c5e6186fd7017

I see now that this should solve a lot of weird issues, and reduce complexity, by A LOT (sorry Avarian). We’ve seen issues with the `unreadCount` being sent to the wrong client when fetching conversation. This is due to when we `reduce` conversations, we get the wrong `participant_identifier` unread count. Said change will fix this, even without reducing anything 😎

After a brainstorm with Avarian we have come up with a few ideas. We can now disregard the table above (I’ll still keep it). Also, groups are back!

We’ll create a relation between `message_conversations` and `message_participants`

An example for a `message_conversation` would be: 1 | 911+311 | 255

Where the first column, is the `conversation_id` , then `conversation_list` which contains all the phone numbers, and at last the `last_message_id`

The `message_participants` would just contain a row of a id, conversation_id and their phone number.

### General stuff, I guess? Or maybe ‘Functionality’

Most of the existing functionality, as sending messages, fetching messages, will most likely stay the same. Although there are cases where for example, transactions would be preferred, which I’ll have to look into closer. One example is when we’re creating conversations.

### API

People, or mostly roleplay fanatics wants a way to both listen to and send messages from different resources. The `onMessage` export was introduced recently, which went straight to hell. No surprise there. So let’s figure out how to make it work.

**onMessage**

The tricky export.

Let’s start with a code example, and I’ll try to explain the mess in my brain.

Concept: 

```lua
-- Let's say you have some service number for '911'
exports.npwd:onMessage("911", function(ctx)
	TriggerEvent("notifyPolice", ctx.message)

	ctx.respond("The police have been notified")
end)
```

The ctx contains the `source` from the player who sent the message. As well as the PreDBMessage data. This already exists in the export today.

...TBA

**emitMessage**

Concept:

```lua
-- Is this weird Lua formatting?
exports.npwd:emitMessage({ senderNumber = "7654321", targetNumber = "1234567", message = "Hello Taso" })
```

**createConversation**

This is pretty straight forward. Would take in two numbers, and npwd does some magic.