### PR TITLE
fix(app/marketplace): removed elevation from market container

### DIFF
--- a/phone/src/apps/marketplace/components/MarketplaceList/MarketplaceItem.tsx
+++ b/phone/src/apps/marketplace/components/MarketplaceList/MarketplaceItem.tsx
@@ -49,7 +49,7 @@ export const MarketplaceItem: React.FC<MarketplaceListing> = ({ children, ...lis
   return (
     <ListItem className={classes.root}>
       <div className={classes.content}>
-        <Paper elevation={2} variant="outlined" className={classes.paper}>
+        <Paper variant="outlined" className={classes.paper}>
           <div style={{ margin: 10 }}>
             <Typography style={{ margin: 5 }} variant="h5">
               {listing.name}


### PR DESCRIPTION
**Pull Request Description**

```react_devtools_backend.js:4061 Warning: Failed prop type: MUI: Combining `elevation={2}` with `variant="outlined"` has no effect. Either use `elevation={0}` or use a different `variant`.
    at Paper (Users/antonstjernquist/dev/private/npwd/phone/node_modules/@mui/material/Paper/Paper.js:90:82)```


**Pull Request Checklist**:
* [X] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [-] Have you built and tested NPWD in-game after the relevant change?
