### PR TITLE
ci(tagged-releases): Automatic fxmanifest version bump

### DIFF
--- a/.github/actions/bump-manifest-version.js
+++ b/.github/actions/bump-manifest-version.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+const newVersion = process.env.TGT_RELEASE_VERSION
+
+const manifestFile = fs.readFileSync('fxmanifest.lua', {encoding: 'utf8'})
+
+const newFileContent = manifestFile.replace(/\bversion\s+(.*)$/gm, `version '${newVersion}'`)
+
+fs.writeFileSync('fxmanifest.lua', newFileContent) 

--- a/.github/workflows/tagged-releases.yml
+++ b/.github/workflows/tagged-releases.yml
@@ -71,3 +71,26 @@ jobs:
         env:
           CI: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  bump-manifest-version:
+    name: 'Bump fxmanifest version'
+    needs: create-tagged-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Bump manifest version
+        run: node .github/actions/bump-manifest-version.js
+        env:
+          TGT_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+      - name: Push manifest change
+        uses: EndBug/add-and-commit@v8
+        with:
+          add: fxmanifest.lua
+          push: true
+          author_name: Manifest Bumper
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          message: 'chore(bump-manifest): Bump manifest version to ${{ env.RELEASE_VERSION }}'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,6 +2,7 @@ fx_version "cerulean"
 game "gta5"
 description 'js runtime monkaW'
 authors { "itschip",  "erik-sn", "TasoOneAsia", "kidz", "RockySouthpaw"}
+version '1.2.91'
 
 client_scripts {
     'resources/dist/client/client.js',


### PR DESCRIPTION
**Pull Request Description**

Based on #619 with minor tweaks and fixes.
The job will run once the create-tagged-release job is finished to avoid situations where the job failed but the manifest was updated anyways.

The ci was tested on my fork with the sentry step removed.

Resolves #616.

**Pull Request Checklist**:
* [X] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [X] Have you built and tested NPWD in-game after the relevant change?
