### PR TITLE
fix(client): Add slash to chat suggestion

### DIFF
--- a/resources/client/cl_main.ts
+++ b/resources/client/cl_main.ts
@@ -34,7 +34,7 @@ RegisterKeyMapping(
 );
 
 setTimeout(() => {
-  emit('chat:addSuggestion', `${config.general.toggleCommand}`, 'Toggle displaying your cellphone');
+  emit('chat:addSuggestion', `/${config.general.toggleCommand}`, 'Toggle displaying your cellphone');
 }, 1000);
 
 const getCurrentGameTime = () => {


### PR DESCRIPTION
**Pull Request Description**
Added slash to chat command suggestion because it was missing.

**Before** - Suggestion was shown even without writing a slash before it.
![before](https://user-images.githubusercontent.com/71350868/165824237-d42d91a2-198a-4db4-85db-bddf838bf305.png)

**After** - 👍🏼
![after](https://user-images.githubusercontent.com/71350868/165823531-f3cb0c09-fae0-4cbb-a756-74373087ea51.png)

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
