### PR TITLE
fix(phone/notibar): don't apply text transform to cell provider

### DIFF
--- a/phone/src/os/notifications/components/NotificationBar.tsx
+++ b/phone/src/os/notifications/components/NotificationBar.tsx
@@ -115,7 +115,7 @@ export const NotificationBar = () => {
             <SignalIcon fontSize="small" />
           </Grid>
           <Grid item className={classes.item}>
-            <Typography className={classes.text} variant="button">
+            <Typography className={classes.text} variant="button" sx={{ textTransform: 'none' }}>
               {Default.cellProvider}
             </Typography>
           </Grid>


### PR DESCRIPTION
**Pull Request Description**

Do not apply any text transformations to the cell provider in the notification bar. Closes #774

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
