### PR TITLE
perf(phone/twitter): utilize xss package in lieu of DOMPurify

### DIFF
--- a/phone/package.json
+++ b/phone/package.json
@@ -14,7 +14,6 @@
     "@mui/material": "^5.2.1",
     "@mui/styles": "^5.2.1",
     "dayjs": "^1.10.7",
-    "dompurify": "^2.3.3",
     "emoji-mart": "^3.0.1",
     "fivem-nui-react-lib": "^2.2.8",
     "i18next": "^20.6.1",
@@ -28,7 +27,8 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "^5.0.0",
-    "recoil": "^0.7.2"
+    "recoil": "^0.7.2",
+    "xss": "^1.0.13"
   },
   "devDependencies": {
     "@craco/craco": "^6.1.1",

--- a/phone/src/apps/twitter/components/tweet/Tweet.tsx
+++ b/phone/src/apps/twitter/components/tweet/Tweet.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import DOMPurify from 'dompurify';
+import xss from 'xss';
 import { useTranslation } from 'react-i18next';
 import { ListItemAvatar, Avatar as MuiAvatar } from '@mui/material';
 
@@ -53,9 +53,11 @@ export const Tweet = (tweet: FormattedTweet) => {
   const formattedMessage = message.replace(/\n\r?/g, '<br />');
 
   // Therefore we need to sanitize this message to protect against XSS
-  const sanitizedMessage = DOMPurify.sanitize(formattedMessage, {
+  const sanitizedMessage = xss(formattedMessage, {
     // Be as strict as possible, whitelisting <br> tag
-    ALLOWED_TAGS: ['br'],
+    whiteList: {
+      br: [],
+    },
   });
 
   const profileName = isRetweet ? retweetProfileName : profile_name;

--- a/phone/yarn.lock
+++ b/phone/yarn.lock
@@ -4718,7 +4718,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5061,6 +5061,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 cssnano-preset-default@^5.1.9:
   version "5.1.9"
@@ -5441,11 +5446,6 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
   dependencies:
     domelementtype "^2.2.0"
-
-dompurify@^2.3.3:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.5.tgz#c83ed5a3ae5ce23e52efe654ea052ffb358dd7e3"
-  integrity sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ==
 
 domutils@^1.7.0:
   version "1.7.0"
@@ -11809,6 +11809,14 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xss@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.13.tgz#6e48f616128b39f366dfadc57411e1eb5b341c6c"
+  integrity sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
**Pull Request Description**
The XSS package is significantly smaller compared to DOMPurify, while still adequately mitigating against the possible XSS vector when processing Tweet content.

Sizes (Unpacked):
DOMPurify - 676 kB
XSS - 146 kB

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
