### PR TITLE
fix: change image filtering

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -35,13 +35,13 @@
     "embedUnsafeImages": false,
     "embedUrl": "https://i.example.com/embed",
     "safeImageUrls": [
-      "imgur.com",
+      "i.imgur.com",
       "file.glass",
       "dropbox.com",
-      "tenor.com",
+      "c.tenor.com",
       "discord.com",
-      "discordapp.com",
-      "wikipedia.org",
+      "cdn.discordapp.com",
+      "upload.wikipedia.org",
       "i.projecterror.dev"
     ]
   },

--- a/config.default.json
+++ b/config.default.json
@@ -36,11 +36,12 @@
     "embedUrl": "https://i.example.com/embed",
     "safeImageUrls": [
       "i.imgur.com",
-      "file.glass",
+      "i.file.glass",
       "dropbox.com",
       "c.tenor.com",
       "discord.com",
       "cdn.discordapp.com",
+      "media.discordapp.com",
       "upload.wikipedia.org",
       "i.projecterror.dev"
     ]

--- a/resources/server/utils/imageFiltering.ts
+++ b/resources/server/utils/imageFiltering.ts
@@ -1,7 +1,5 @@
 import { config } from '../config';
 
-const imageRegex = new RegExp(config.imageSafety.safeImageUrls.join('|'));
-
 export const checkAndFilterImage = (imageUrl: string): string | null => {
   const image = imageUrl.trim();
   if (image == '') {
@@ -11,8 +9,9 @@ export const checkAndFilterImage = (imageUrl: string): string | null => {
   // If we don't care about filtering images just return the image
   if (!config.imageSafety.filterUnsafeImageUrls) return image;
 
+  const hostname = new URL(imageUrl).hostname;
   // We have an allowed image url!
-  if (imageRegex.test(image)) return image;
+  if (config.imageSafety.safeImageUrls.includes(hostname)) return image;
 
   // Embed unsafe urls so we don't accidentally expose our users IP address
   if (config.imageSafety.embedUnsafeImages) return `${config.imageSafety.embedUrl}?url=${imageUrl}`;


### PR DESCRIPTION
**Pull Request Description**

Change image filtering to fix users being able to put this in a url:
`https://attacker.com/imgur.com`
With the old code this would be considered a safe url because it contains imgur.com, now it actually checks the hostname with a new URL object.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
