### PR TITLE
fix(phone/keyboard): Swap onFocus attributes to onMouseUp to fix weapon firing

### DIFF
--- a/phone/src/apps/contacts/components/ContactsApp.tsx
+++ b/phone/src/apps/contacts/components/ContactsApp.tsx
@@ -9,7 +9,7 @@ import { ContactPage } from './views/ContactsPage';
 import { ContactsThemeProvider } from '../providers/ContactsThemeProvider';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import Fab from '@mui/material/Fab';
-import { useHistory, useLocation } from 'react-router';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Theme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import { LoadingSpinner } from '@ui/components/LoadingSpinner';

--- a/phone/src/apps/contacts/components/ContactsApp.tsx
+++ b/phone/src/apps/contacts/components/ContactsApp.tsx
@@ -9,10 +9,11 @@ import { ContactPage } from './views/ContactsPage';
 import { ContactsThemeProvider } from '../providers/ContactsThemeProvider';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import Fab from '@mui/material/Fab';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router';
 import { Theme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import { LoadingSpinner } from '@ui/components/LoadingSpinner';
+import { toggleKeys } from '@ui/components';
 
 const useStyles = makeStyles((theme: Theme) => ({
   absolute: {
@@ -45,6 +46,7 @@ export const ContactsApp: React.FC = () => {
             color="primary"
             onClick={() => history.push('/contacts/-1')}
             className={classes.absolute}
+            onMouseUp={() => {toggleKeys(false);}}
           >
             <PersonAddIcon />
           </Fab>

--- a/phone/src/apps/dialer/components/DialerInput.tsx
+++ b/phone/src/apps/dialer/components/DialerInput.tsx
@@ -9,6 +9,7 @@ import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { InputBase } from '@ui/components/Input';
 import { useCall } from '@os/call/hooks/useCall';
+import { toggleKeys } from '@ui/components/Input';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -65,6 +66,7 @@ export const DialerInput: React.FC = () => {
       <IconButton
         className={classes.iconBtn}
         onClick={() => handleNewContact(inputVal)}
+        onMouseUp={() => {toggleKeys(false);}}
         size="large"
       >
         <PersonAddIcon fontSize="large" />

--- a/phone/src/apps/messages/components/MessagesApp.tsx
+++ b/phone/src/apps/messages/components/MessagesApp.tsx
@@ -40,7 +40,7 @@ export const MessagesApp = () => {
             </React.Suspense>
           </AppContent>
           <Route exact path="/messages">
-            <NewMessageGroupButton onClick={() => history.push('/messages/new')} onMouseUp={() => {toggleKeys(false);}}/>
+            <NewMessageGroupButton onClick={() => history.push('/messages/new')} />
           </Route>
         </WordFilterProvider>
       </AppWrapper>

--- a/phone/src/apps/messages/components/MessagesApp.tsx
+++ b/phone/src/apps/messages/components/MessagesApp.tsx
@@ -11,6 +11,7 @@ import NewMessageGroupButton from './form/NewMessageGroupButton';
 import { MessagesThemeProvider } from '../providers/MessagesThemeProvider';
 import { LoadingSpinner } from '@ui/components/LoadingSpinner';
 import { WordFilterProvider } from '@os/wordfilter/providers/WordFilterProvider';
+import { toggleKeys } from '@ui/components';
 
 export const MessagesApp = () => {
   const messages = useApp('MESSAGES');
@@ -39,7 +40,7 @@ export const MessagesApp = () => {
             </React.Suspense>
           </AppContent>
           <Route exact path="/messages">
-            <NewMessageGroupButton onClick={() => history.push('/messages/new')} />
+            <NewMessageGroupButton onClick={() => history.push('/messages/new')} onMouseUp={() => {toggleKeys(false);}}/>
           </Route>
         </WordFilterProvider>
       </AppWrapper>

--- a/phone/src/apps/messages/components/form/NewMessageGroupButton.tsx
+++ b/phone/src/apps/messages/components/form/NewMessageGroupButton.tsx
@@ -4,6 +4,7 @@ import { Add, Delete } from '@mui/icons-material';
 import { Fab } from '@mui/material';
 import { useCheckedConversationsValue, useIsEditing } from '../../hooks/state';
 import { useMessageAPI } from '../../hooks/useMessageAPI';
+import { toggleKeys } from '@ui/components';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -15,7 +16,6 @@ const useStyles = makeStyles((theme) => ({
 
 interface NewMessageGroupButtonProps {
   onClick(): void;
-  onMouseUp(): void,
 }
 
 export const NewMessageGroupButton: React.FC<NewMessageGroupButtonProps> = ({ onClick }) => {
@@ -34,6 +34,7 @@ export const NewMessageGroupButton: React.FC<NewMessageGroupButtonProps> = ({ on
       className={classes.root}
       color="primary"
       onClick={!isEditing ? onClick : handleDeleteConversations}
+      onMouseUp={() => {toggleKeys(false);}}
     >
       {!isEditing ? <Add /> : <Delete />}
     </Fab>

--- a/phone/src/apps/messages/components/form/NewMessageGroupButton.tsx
+++ b/phone/src/apps/messages/components/form/NewMessageGroupButton.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
 
 interface NewMessageGroupButtonProps {
   onClick(): void;
+  onMouseUp(): void,
 }
 
 export const NewMessageGroupButton: React.FC<NewMessageGroupButtonProps> = ({ onClick }) => {

--- a/phone/src/apps/twitter/components/buttons/TweetButton.tsx
+++ b/phone/src/apps/twitter/components/buttons/TweetButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { Fab } from '@mui/material';
 import CreateIcon from '@mui/icons-material/Create';
+import { toggleKeys } from '@ui/components';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -19,7 +20,7 @@ export function TweetButton({ openModal }) {
 
   return (
     <div className={classes.root}>
-      <Fab className={classes.button} color="primary" onClick={openModal}>
+      <Fab className={classes.button} color="primary" onClick={openModal} onMouseUp={() => {toggleKeys(false);}}>
         <CreateIcon />
       </Fab>
     </div>

--- a/phone/src/os/keyboard/hooks/useKeyboardService.ts
+++ b/phone/src/os/keyboard/hooks/useKeyboardService.ts
@@ -102,11 +102,10 @@ export const useKeyboardService = () => {
   );
 
   const closePhoneHandler = (event) => {
-    if (['input', 'textarea'].includes(event.target.nodeName.toLowerCase()) || call) {
-      return;
+    if (['input', 'textarea'].includes(event.target.nodeName.toLowerCase())) {
+      event.target.blur();
     }
-
-    closePhone();
+      closePhone();  
   };
 
   useEffect(

--- a/phone/src/ui/components/Input.tsx
+++ b/phone/src/ui/components/Input.tsx
@@ -18,10 +18,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
     ref={ref}
     {...props}
     variant={props.variant ?? 'standard'}
-    onFocus={(e) => {
+    onMouseUp={(e) => {
       toggleKeys(false);
-      if (props.onFocus) {
-        props.onFocus(e);
+      if (props.onMouseUp) {
+        props.onMouseUp(e);
       }
     }}
     onBlur={(e) => {
@@ -37,10 +37,10 @@ export const InputBase: React.FC<InputBaseProps> = forwardRef((props, ref) => (
   <MUIInputBase
     ref={ref}
     {...props}
-    onFocus={(e) => {
+    onMouseUp={(e) => {
       toggleKeys(false);
-      if (props.onFocus) {
-        props.onFocus(e);
+      if (props.onMouseUp) {
+        props.onMouseUp(e);
       }
     }}
     onBlur={(e) => {

--- a/phone/src/ui/components/Input.tsx
+++ b/phone/src/ui/components/Input.tsx
@@ -30,9 +30,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
         props.onBlur(e);
       }
     }}
-    onFocusCapture={() => {
-      toggleKeys(false);
-    }}
   />
 ));
 
@@ -51,9 +48,6 @@ export const InputBase: React.FC<InputBaseProps> = forwardRef((props, ref) => (
       if (props.onBlur) {
         props.onBlur(e);
       }
-    }}
-    onFocusCapture={() => {
-      toggleKeys(false);
     }}
   />
 ));

--- a/phone/src/ui/components/Input.tsx
+++ b/phone/src/ui/components/Input.tsx
@@ -30,6 +30,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
         props.onBlur(e);
       }
     }}
+    onFocusCapture={() => {
+      toggleKeys(false);
+    }}
   />
 ));
 
@@ -48,6 +51,9 @@ export const InputBase: React.FC<InputBaseProps> = forwardRef((props, ref) => (
       if (props.onBlur) {
         props.onBlur(e);
       }
+    }}
+    onFocusCapture={() => {
+      toggleKeys(false);
     }}
   />
 ));


### PR DESCRIPTION
**Pull Request Description**

This PR aims to fix the weapon firing bug when a user clicks to focus an element.  The onFocus attribute used for the input fields was changed to onMouseUp to prevent firing the toggleKeys function simultaneously when the user pressed their mouse click (since firing the function at the same time the click is pressed will cause the bug to re-occur given the way that SetNuiFocusKeepInput functions).
