### PR TITLE
Fix home route loading external apps too

### DIFF
--- a/apps/phone/config/webpack.production.js
+++ b/apps/phone/config/webpack.production.js
@@ -59,6 +59,14 @@ module.exports = () => ({
           singleton: true,
           requiredVersion: deps['react-dom'],
         },
+        'react-router-dom': {
+          singleton: true,
+          requiredVersion: deps['react-router-dom'],
+        },
+        'recoil': {
+          singleton: true,
+          requiredVersion: deps['recoil'],
+        }
       },
     }),
     new HtmlWebpackPlugin({

--- a/apps/phone/src/apps/home/components/Home.tsx
+++ b/apps/phone/src/apps/home/components/Home.tsx
@@ -3,11 +3,12 @@ import { AppWrapper } from '@ui/components';
 import { Box } from '@mui/material';
 import { GridMenu } from '@ui/components/GridMenu';
 import { useApps } from '@os/apps/hooks/useApps';
-import { useExternalApps } from '@common/hooks/useExternalApps';
+import { useRecoilValue } from 'recoil';
+import { phoneState } from '@os/phone/hooks/state';
 
 export const HomeApp: React.FC = () => {
   const { apps } = useApps();
-  const externalApps = useExternalApps();
+  const externalApps = useRecoilValue(phoneState.extApps).filter(Boolean);
   return (
     <AppWrapper>
       <Box component="div" mt={6} px={1}>


### PR DESCRIPTION
**Pull Request Description**

Home app was loading external apps (so is [Phone.tsx](https://github.com/project-error/npwd/blob/master/phone/src/Phone.tsx#L75)) with `useExternalApps()`, making them reload twice initially and everytime you went to the default route `/`.
This pr fixes #896 by only using the external apps already cached in the atom, and only let [Phone.tsx](https://github.com/project-error/npwd/blob/master/phone/src/Phone.tsx#L75) be the one loading them

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
