### PR TITLE
Added virtualize infinite scrolling for twitter feed & hidden contact pay button

### DIFF
--- a/apps/phone/package.json
+++ b/apps/phone/package.json
@@ -31,6 +31,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.14.3",
+    "react-virtuoso": "^4.3.8",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "^5.0.0",

--- a/apps/phone/src/apps/contacts/components/views/ContactInfo.tsx
+++ b/apps/phone/src/apps/contacts/components/views/ContactInfo.tsx
@@ -179,9 +179,11 @@ const ContactsInfoPage: React.FC = () => {
             <button onClick={startCall} className="group flex items-center justify-center rounded-md py-2 dark:bg-neutral-800 dark:hover:bg-neutral-700">
               <Phone className="h-6 w-6 dark:text-neutral-400 dark:group-hover:text-neutral-100" />
             </button>
+            { (ResourceConfig?.general?.useResourceIntegration && ResourceConfig?.contacts?.frameworkPay) &&
             <button onClick={openpayModal} className="group flex items-center justify-center rounded-md py-2 dark:bg-neutral-800 dark:hover:bg-neutral-700">
               <HelpingHand className="h-6 w-6 dark:text-neutral-400 dark:group-hover:text-neutral-100" />
             </button>
+            }
             <button
               onClick={handleContactDelete}
               className="group flex items-center justify-center rounded-md py-2 dark:bg-red-100 dark:hover:bg-red-200"

--- a/apps/phone/src/apps/twitter/components/tweet/TweetList.tsx
+++ b/apps/phone/src/apps/twitter/components/tweet/TweetList.tsx
@@ -7,10 +7,11 @@ import { ServerPromiseResp } from '@typings/common';
 import fetchNui from '@utils/fetchNui';
 import { processTweet } from '@apps/twitter/utils/tweets';
 import { usePhone } from '@os/phone/hooks';
+import { useSnackbar } from '@os/snackbar/hooks/useSnackbar';
 
 export function TweetList({ tweets }: { tweets: FormattedTweet[] }) {
   const { ResourceConfig } = usePhone();
-
+  const { addAlert } = useSnackbar();
   const TWEET_LIMIT_PER_PAGE  = ResourceConfig?.twitter?.resultsLimit || 25;
   const [imageOpen, setImageOpen] = useState<string | null>(null);
   const [tweetsData, setTweetsData] = useState(tweets);
@@ -25,7 +26,10 @@ export function TweetList({ tweets }: { tweets: FormattedTweet[] }) {
     const pageId = page + 1
     fetchNui<ServerPromiseResp<GetTweet[]>>(TwitterEvents.FETCH_TWEETS, {pageId}).then((resp) => {
       if (resp.status !== 'ok') {
-        console.log(resp.errorMsg || '')
+        addAlert({
+          message: resp.errorMsg,
+          type: 'error',
+        });
       } else {
         const newTweets = resp.data?.map(processTweet)
         if (newTweets.length < TWEET_LIMIT_PER_PAGE) {
@@ -42,7 +46,7 @@ export function TweetList({ tweets }: { tweets: FormattedTweet[] }) {
       }, 350);
 
     });
-  }, [setTweetsData])
+  }, [addAlert, setTweetsData])
 
   const Footer = () => {
     if (hasNextPage) {

--- a/apps/phone/src/apps/twitter/components/tweet/TweetList.tsx
+++ b/apps/phone/src/apps/twitter/components/tweet/TweetList.tsx
@@ -1,21 +1,78 @@
-import { memo, useState } from 'react';
-
-import { List } from '@ui/components/List';
+import { memo, useCallback, useState } from 'react';
 import Tweet from './Tweet';
-import { FormattedTweet } from '@typings/twitter';
+import { Virtuoso } from 'react-virtuoso';
+import { FormattedTweet, GetTweet, TwitterEvents } from '@typings/twitter';
 import Backdrop from '@ui/components/Backdrop';
+import { ServerPromiseResp } from '@typings/common';
+import fetchNui from '@utils/fetchNui';
+import { processTweet } from '@apps/twitter/utils/tweets';
+import { usePhone } from '@os/phone/hooks';
 
 export function TweetList({ tweets }: { tweets: FormattedTweet[] }) {
+  const { ResourceConfig } = usePhone();
+
+  const TWEET_LIMIT_PER_PAGE  = ResourceConfig?.twitter?.resultsLimit || 25;
   const [imageOpen, setImageOpen] = useState<string | null>(null);
+  const [tweetsData, setTweetsData] = useState(tweets);
+  const [hasNextPage, setHasNextPage] = useState(tweetsData.length == TWEET_LIMIT_PER_PAGE ? true : false);
+  const [page, setPage] = useState(0);
+  const [isNextPageLoading, setIsNextPageLoading] = useState(false);
+
+  const handleNewPageLoad = useCallback(() => {
+    if (isNextPageLoading || !hasNextPage) return;
+    setIsNextPageLoading(true);
+
+    const pageId = page + 1
+    fetchNui<ServerPromiseResp<GetTweet[]>>(TwitterEvents.FETCH_TWEETS, {pageId}).then((resp) => {
+      if (resp.status !== 'ok') {
+        console.log(resp.errorMsg || '')
+      } else {
+        const newTweets = resp.data?.map(processTweet)
+        if (newTweets.length < TWEET_LIMIT_PER_PAGE) {
+          setHasNextPage(false);
+        }
+        setTweetsData([...tweetsData, ...newTweets])
+        setPage(pageId);
+      }
+
+      //Maybe a better way to do this?
+      //Prevents the "250" rate limit if someone is scrolling too fast
+      return setTimeout(() => { 
+        setIsNextPageLoading(false);
+      }, 350);
+
+    });
+  }, [setTweetsData])
+
+  const Footer = () => {
+    if (hasNextPage) {
+      return (
+        <div style={{padding: '2rem', display: 'flex', justifyContent: 'center', color: '#64A5FD'}}>
+          Loading Tweets...
+        </div>
+      );
+    } else {
+      return (
+        <div style={{padding: '2rem', display: 'flex', justifyContent: 'center', color: '#64A5FD'}}>
+          Nothing More To Load!
+        </div>
+      );
+    }
+  }
 
   return (
-    <>  
-      {imageOpen && <Backdrop onClick={() => setImageOpen(null)} />}
-      <List>
-        {tweets.map((tweet) => (
-          <Tweet key={tweet.id} tweet={tweet} imageOpen={imageOpen} setImageOpen={setImageOpen} />
-        ))}
-      </List>
+    <>
+    {imageOpen && <Backdrop onClick={() => setImageOpen(null)} />}
+    <Virtuoso
+      style={{height: '100%'}}
+      data={tweetsData}
+      endReached={handleNewPageLoad}
+      overscan={6}
+      itemContent={(index, tweet) => {
+        return <Tweet key={tweet.id} tweet={tweet} imageOpen={imageOpen} setImageOpen={setImageOpen} />
+      }}
+      components={{ Footer }}
+    />
     </>
   );
 }

--- a/config.default.json
+++ b/config.default.json
@@ -75,7 +75,8 @@
     "enableEmojis": true,
     "enableImages": true,
     "maxImages": 1,
-    "allowNoMessage": false
+    "allowNoMessage": false,
+    "resultsLimit": 25
   },
   "match": {
     "generateProfileNameFromUsers": true,

--- a/packages/database/src/twitter/index.ts
+++ b/packages/database/src/twitter/index.ts
@@ -27,7 +27,7 @@ const SELECT_FIELDS = `
   TIME_TO_SEC(TIMEDIFF( NOW(), npwd_twitter_tweets.createdAt)) AS seconds_since_tweet
 `;
 
-const TWEETS_PER_PAGE = 25;
+const TWEETS_PER_PAGE = config?.twitter?.resultsLimit || 25;
 
 const formatTweets =
   (profileId: number) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       react-uuid:
         specifier: ^1.0.3
         version: 1.0.3
+      react-virtuoso:
+        specifier: ^4.3.8
+        version: 4.3.8(react-dom@17.0.2)(react@17.0.2)
       recoil:
         specifier: ^0.7.7
         version: 0.7.7(react-dom@17.0.2)(react@17.0.2)
@@ -13736,6 +13739,17 @@ packages:
   /react-uuid@1.0.3:
     resolution: {integrity: sha512-cw6Rr6JphvsdK4xHPGBjKD7XSH6Y6i4NJFWUO3OiDd7NLcR8xVeQ3CfeKm7h+S5tpZZVfbH3Tkrz/ydsIiV8pA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dev: false
+
+  /react-virtuoso@4.3.8(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-hoZj8Dl1R9fYqtUwA5LjCii1djO4ZNtoYkYsR52ZjdJzdXh2hec1IQ2O+1MZNjLTb4v8ff3hbt34StiHTVDdlg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18'
+      react-dom: '>=16 || >=17 || >= 18'
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /react@17.0.2:

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -12,6 +12,7 @@ interface TwitterConfig {
   enableImages: boolean;
   maxImages: number;
   allowNoMessage: boolean;
+  resultsLimit: number;
 }
 
 interface MatchConfig {


### PR DESCRIPTION
**Pull Request Description**

- Added infinite scrolling for twitter tweets with virtualization of DOM elements
- Added new config option to change the limit of results per request for tweets.
- Hide pay contact button when config is disabled


**Pull Request Checklist**:
* [✓] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [✓] Have you built and tested NPWD in-game after the relevant change?

Concept of infinite scrolling while limiting the DOM elements to just what is in the view.. it will only render new DOM elements when the user scrolls up and down while culling elements out of view to keep the performance impact low of having too many DOM elements.

https://gyazo.com/e39b5b284f605e5c89f34147983954d3

Could likely apply this method to messages in the future and remove the need for the "react-infinite-scroll-component" package which I think is still being used messages
