### PR TITLE
fix(game/server/players): 'this' scope lost to service function

### DIFF
--- a/apps/game/server/players/player.service.ts
+++ b/apps/game/server/players/player.service.ts
@@ -240,9 +240,9 @@ class _PlayerService {
    * @param src - Source of player being unloaded
    **/
   async handleUnloadPlayerEvent(src: number) {
-    await this.clearPlayerData(src);
+    await this.clearPlayerData.bind(this, src);
 
-    this.deletePlayerFromMaps(src);
+    this.deletePlayerFromMaps.bind(this, src);
     emitNet(PhoneEvents.SET_PLAYER_LOADED, src, false);
     playerLogger.info(`Unloaded NPWD Player, source: (${src})`);
   }


### PR DESCRIPTION
**Pull Request Description**

The scope of the 'this' keyword is lost in two methods because they get executed from within the class and use the 'this' keyword themselves, because 'this' is not based on declaration but invocation it gets lost. I solved the issue by simply binding the correct instance of 'this' to the invocation of the function, this solves #1010 

**Pull Request Checklist**:
* [ ] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [ ] Have you built and tested NPWD in-game after the relevant change?
