### PR TITLE
Fix: Contacts App Input boxes were not disabling key actions

### DIFF
--- a/apps/phone/src/apps/contacts/components/List/SearchContacts.tsx
+++ b/apps/phone/src/apps/contacts/components/List/SearchContacts.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
+import { Box } from '@mui/material';
+import { SearchField } from '@ui/components/SearchField';
 import { useDebounce } from '@os/phone/hooks/useDebounce';
 import { useSetContactFilterInput } from '../../hooks/state';
-import { Search } from 'lucide-react';
 
 export const SearchContacts: React.FC = () => {
   const [t] = useTranslation();
@@ -18,16 +19,12 @@ export const SearchContacts: React.FC = () => {
   }, [debouncedVal, setFilterVal]);
 
   return (
-    <div className="w-full py-2 px-4">
-      <div className="flex items-center justify-start bg-neutral-200 dark:bg-neutral-800 rounded-md px-2 space-x-2">
-        <Search className="h-5 w-5 dark:text-neutral-400" />
-        <input
-          className="w-full text-base dark:text-neutral-100 py-2 bg-transparent outline-none "
-          onChange={(e) => setInputVal(e.target.value)}
-          placeholder={t('CONTACTS.PLACEHOLDER_SEARCH_CONTACTS')}
-          value={inputVal}
-        />
-      </div>
-    </div>
+    <Box>
+      <SearchField
+        value={inputVal}
+        onChange={(e) => setInputVal(e.target.value)}
+        placeholder={t('CONTACTS.PLACEHOLDER_SEARCH_CONTACTS')}
+      />
+    </Box>
   );
 };

--- a/apps/phone/src/apps/contacts/components/views/ContactInfo.tsx
+++ b/apps/phone/src/apps/contacts/components/views/ContactInfo.tsx
@@ -7,7 +7,8 @@ import { useCall } from '@os/call/hooks/useCall';
 import { useMyPhoneNumber } from '@os/simcard/hooks/useMyPhoneNumber';
 import useMessages from '../../../messages/hooks/useMessages';
 import { useQueryParams } from '@common/hooks/useQueryParams';
-import { NPWDButton, NPWDInput as Input } from '@ui/components';
+import { NPWDButton } from '@ui/components';
+import { InputBase } from '@ui/components/Input';
 import { ContactsDatabaseLimits } from '@typings/contact';
 import { useContactsAPI } from '../../hooks/useContactsAPI';
 import { SendMoneyModal } from '../../components/modals/SendMoney';
@@ -53,6 +54,13 @@ const useStyles = makeStyles({
   inputProps: {
     fontSize: 22,
   },
+  button: {
+    color: "#000000",
+    backgroundColor: "#838383",
+    '&:hover': {
+      backgroundColor: "#6a6a6a",
+    }
+  }
 });
 
 const ContactsInfoPage: React.FC = () => {
@@ -164,10 +172,14 @@ const ContactsInfoPage: React.FC = () => {
           <img src={avatar} className="mx-auto h-24 w-24 rounded-full text-center" />
         </div>
         <div className="mt-8">
-          <Input
-            placeholder={t('CONTACTS.FORM_NAME')}
+          <div className="text-sm font-medium dark:text-neutral-400">
+            {t('CONTACTS.FORM_NAME')}
+          </div>
+          <InputBase
             value={name}
             onChange={handleDisplayChange}
+            fullWidth
+            sx={{ backgroundColor: "#363636ad", padding: "8px", borderRadius: "5px" }}
           />
         </div>
 
@@ -195,24 +207,24 @@ const ContactsInfoPage: React.FC = () => {
 
         <div className="mt-8 space-y-4">
           <div>
-            <label className="text-sm font-medium dark:text-neutral-400">
+            <div className="text-sm font-medium dark:text-neutral-400">
               {t('CONTACTS.FORM_NUMBER')}
-            </label>
-            <Input value={number} onChange={handleNumberChange} />
+            </div>
+            <InputBase value={number} onChange={handleNumberChange} fullWidth sx={{ backgroundColor: "#363636ad", padding: "8px", borderRadius: "5px" }} />
           </div>
           <div>
-            <label className="text-sm font-medium dark:text-neutral-400">
+            <div className="text-sm font-medium dark:text-neutral-400">
               {t('CONTACTS.FORM_AVATAR')}
-            </label>
-            <Input value={avatar} onChange={handleAvatarChange} />
+            </div>
+            <InputBase value={avatar} onChange={handleAvatarChange} fullWidth sx={{ backgroundColor: "#363636ad", padding: "8px", borderRadius: "5px" }} />
           </div>
         </div>
 
         <div className="mt-8">
           {contact ? (
-            <NPWDButton onClick={handleContactUpdate}>{t('GENERIC.UPDATE')}</NPWDButton>
+            <NPWDButton onClick={handleContactUpdate} className={classes.button}>{t('GENERIC.UPDATE')}</NPWDButton>
           ) : (
-            <NPWDButton onClick={handleContactAdd}>{t('GENERIC.ADD')}</NPWDButton>
+            <NPWDButton onClick={handleContactAdd} className={classes.button}>{t('GENERIC.ADD')}</NPWDButton>
           )}
         </div>
       </div>


### PR DESCRIPTION
**Pull Request Description**

On the Contacts App, ContactInfo component, the three `<Input />` fields were not disabling keys. 
If a player used WASD it would allow them to walk even while the input had focus, and other keys that were bound would also trigger.

Switched the component to use the `<InputBase />` component which is properly handling the keypresses. As a result of changing to this Input box, the component had to have the styles re-applied, so some style override changes were added.
BEFORE
![image](https://github.com/project-error/npwd/assets/18689469/f938bd9f-b1b9-48f8-a276-728b9c79d422)

AFTER
![image](https://github.com/project-error/npwd/assets/18689469/2668b89d-e917-4c03-80d9-6cfeacbe6b81)


The Search box had the same issue so I used the `<SearchField />` component that other apps (like Messaging) are using.
BEFORE
![image](https://github.com/project-error/npwd/assets/18689469/7ad343ae-2a5e-4b72-a58f-090db782048b)

AFTER
![image](https://github.com/project-error/npwd/assets/18689469/c035097c-b898-4095-95f7-1573f380ac3f)



Recording showing that it no longer tries to make you move:
https://clipchamp.com/watch/JnjnPZK90pY

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
