### PR TITLE
Twitter: Broadcast twitter add / remove like and notify user when their tweet is liked

### DIFF
--- a/apps/game/client/cl_twitter.ts
+++ b/apps/game/client/cl_twitter.ts
@@ -16,3 +16,11 @@ RegisterNuiProxy(TwitterEvents.RETWEET);
 onNet(TwitterEvents.CREATE_TWEET_BROADCAST, (tweet: any) => {
   sendTwitterMessage(TwitterEvents.CREATE_TWEET_BROADCAST, tweet);
 });
+
+onNet(TwitterEvents.TWEET_LIKED_BROADCAST, (
+  tweetId: number,
+  isAddLike: boolean,
+  likedByProfileName: string
+) => {
+  sendTwitterMessage(TwitterEvents.TWEET_LIKED_BROADCAST, {tweetId, isAddLike, likedByProfileName});
+});

--- a/apps/game/server/twitter/twitter.service.ts
+++ b/apps/game/server/twitter/twitter.service.ts
@@ -216,6 +216,7 @@ class _TwitterService {
       const identifier = PlayerService.getIdentifier(reqObj.source);
       const profile = await this.twitterDB.getOrCreateProfile(identifier);
       const likeExists = await this.twitterDB.doesLikeExist(profile.id, reqObj.data.tweetId);
+      const likedByProfileName = profile.profile_name;
 
       if (likeExists) {
         await this.twitterDB.deleteLike(profile.id, reqObj.data.tweetId);
@@ -224,6 +225,7 @@ class _TwitterService {
       }
 
       resp({ status: 'ok' });
+      emitNet(TwitterEvents.TWEET_LIKED_BROADCAST, -1, reqObj.data.tweetId, !likeExists, likedByProfileName);
     } catch (e) {
       twitterLogger.error(`Like failed, ${e.message}`, {
         source: reqObj.source,

--- a/apps/phone/src/apps/twitter/hooks/useTwitterActions.ts
+++ b/apps/phone/src/apps/twitter/hooks/useTwitterActions.ts
@@ -11,6 +11,7 @@ interface TwitterActionProps {
   deleteTweet: (tweetId: number) => void;
   updateLocalProfile: (profile: UpdateProfileProps) => void;
   localToggleLike: (tweetId: number) => void;
+  updateTweetLikes: (tweetId: number, isAddLike: boolean) => void;
 }
 
 const getIsTweetsLoading = (snapshot: Snapshot) =>
@@ -70,6 +71,7 @@ export const useTwitterActions = (): TwitterActionProps => {
     [setTweets],
   );
 
+  // Toggles the isLiked field
   const localToggleLike = useCallback(
     (tweetId: number) => {
       setTweets((curVal) =>
@@ -78,7 +80,6 @@ export const useTwitterActions = (): TwitterActionProps => {
             return {
               ...tweet,
               isLiked: tweet.isLiked ? false : true,
-              likes: tweet.isLiked ? tweet.likes - 1 : tweet.likes + 1,
             };
           }
           return tweet;
@@ -88,6 +89,23 @@ export const useTwitterActions = (): TwitterActionProps => {
     [setTweets],
   );
 
+  // Updates the tweet likes count, adds or subtracts depending on isAddLike
+  const updateTweetLikes = useCallback((tweetId: number, isAddLike: boolean) => {
+    setTweets((curVal) =>
+      [...curVal].map((tweet) => {
+        if (tweet.id === tweetId) {
+          return {
+            ...tweet,
+            likes: isAddLike ? tweet.likes + 1 : tweet.likes - 1,
+          };
+        }
+        return tweet;
+      }),
+    );
+  },
+  [setTweets],
+  );
+
   return {
     updateTweets,
     updateFilteredTweets,
@@ -95,5 +113,6 @@ export const useTwitterActions = (): TwitterActionProps => {
     deleteTweet,
     updateLocalProfile,
     localToggleLike,
+    updateTweetLikes,
   };
 };

--- a/apps/phone/src/apps/twitter/hooks/useTwitterService.ts
+++ b/apps/phone/src/apps/twitter/hooks/useTwitterService.ts
@@ -8,7 +8,7 @@ import { Tweet, TwitterEvents } from '@typings/twitter';
 import { useTwitterActions } from './useTwitterActions';
 import { processBroadcastedTweet, processTweet } from '../utils/tweets';
 import { useNotification } from '@os/new-notifications/useNotification';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 /**
  * Service to handle all NUI <> client interactions. We take
@@ -18,10 +18,8 @@ import { useLocation, useRouteMatch } from 'react-router-dom';
  * there and have moved that logic here instead.
  */
 
-// TODO: Bring back notifications
-
 export const useTwitterService = () => {
-  const { addTweet } = useTwitterActions();
+  const { addTweet, updateTweetLikes } = useTwitterActions();
   const [tweets, setTweets] = useTweetsState();
   const { enqueueNotification } = useNotification();
   const { pathname } = useLocation();
@@ -36,12 +34,25 @@ export const useTwitterService = () => {
   };
 
   const addNotification = useCallback(
-    (data: any) => {
+    (tweet: Tweet) => {
       enqueueNotification({
         appId: 'TWITTER',
-        content: data.message,
+        content: tweet.message,
         notisId: 'npwd:tweetBroadcast',
-        secondaryTitle: data.profile_name,
+        secondaryTitle: tweet.profile_name,
+        path: '/twitter',
+        playSound: true,
+      });
+    },
+    [enqueueNotification],
+  );
+
+  const addLikedTweetNotification = useCallback(
+    (likedByProfileName: string) => {
+      enqueueNotification({
+        appId: 'TWITTER',
+        content: `@${likedByProfileName} liked your tweet!`,
+        notisId: 'npwd:tweetBroadcast',
         path: '/twitter',
       });
     },
@@ -67,6 +78,28 @@ export const useTwitterService = () => {
     [addTweet, addNotification, profileContent, profileLoading, setTweets, tweets.length, pathname],
   );
 
+  const handleTweetLikedBroadcast = useCallback((
+    {tweetId, isAddLike, likedByProfileName}: {
+      tweetId: number,
+      isAddLike: boolean,
+      likedByProfileName: string
+    }
+  ) => {
+    updateTweetLikes(tweetId, isAddLike);
+
+    // Only notify when a like is added (dont notify when its removed)
+    // Dont notify if you are looking at twitter
+    if (isAddLike && !pathname.includes('/twitter')) {
+      const likedTweet = tweets.find(tweet => tweet.id == tweetId);
+
+      // Only notify if the user is the owner of the tweet and its not a self like
+      if (likedTweet.isMine && likedTweet.profile_name !== likedByProfileName) {
+        addLikedTweetNotification(likedByProfileName);
+      }
+    }
+  }, [addLikedTweetNotification, updateTweetLikes, tweets]);
+
   useNuiEvent(APP_TWITTER, TwitterEvents.FETCH_TWEETS_FILTERED, _setFilteredTweets);
   useNuiEvent(APP_TWITTER, TwitterEvents.CREATE_TWEET_BROADCAST, handleTweetBroadcast);
+  useNuiEvent(APP_TWITTER, TwitterEvents.TWEET_LIKED_BROADCAST, handleTweetLikedBroadcast);
 };

--- a/typings/twitter.ts
+++ b/typings/twitter.ts
@@ -83,4 +83,5 @@ export enum TwitterEvents {
   TOGGLE_LIKE = 'npwd:toggleLike',
   RETWEET = 'npwd:retweet',
   REPORT = 'npwd:reportTweet',
+  TWEET_LIKED_BROADCAST = 'npwd:tweetLikedBroadcast',
 }


### PR DESCRIPTION
**Pull Request Description**
Problem:
When a tweet is liked or a like is removed from a tweet, other users do not see the tweet count changing. A user only sees the count change locally from their own like/remove like. 

This PR solves this problem by broadcasting the add/remove like to all players so that the counts are accurately reflected on all clients and are kept up to date.
- updated `localToggleLike` to only handle toggling the `isLiked` field
- added `updateTweetLikes` that is received on all clients to update the `likes` count by incrementing or decrementing depending on if the like was added/removed

Additionally this PR adds a notification when a user's tweet is liked. Notifications will only show if the user is not currently looking at the twitter app. 
![image](https://github.com/project-error/npwd/assets/18689469/a150e4f2-b05f-4e07-9091-91a30c23e489)

Demo: https://clipchamp.com/watch/sEdY6bgbSMa

Note: The notification `playSound` relies on the change presented in this PR: https://github.com/project-error/npwd/pull/1023

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
   - Built and tested with multiple players simultaneously liking/unliking many posts back to back and the numbers all reflected correctly and updated in real time.
