### PR TITLE
Fix: Add isEnvBrowser check for running app in dev mode

### DIFF
--- a/apps/phone/src/os/phone/hooks/usePhoneVisibility.ts
+++ b/apps/phone/src/os/phone/hooks/usePhoneVisibility.ts
@@ -3,6 +3,7 @@ import { activeNotificationIds } from '@os/new-notifications/state';
 import { useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useSettings } from '../../../apps/settings/hooks/useSettings';
+import { isEnvBrowser } from '../../../utils/misc';
 import { phoneState } from './state';
 
 export const usePhoneVisibility = () => {
@@ -23,7 +24,7 @@ export const usePhoneVisibility = () => {
   }, [hasNotis, activeNotifications, visibility]);
 
   const bottom = useMemo(() => {
-    if (!visibility) {
+    if (!visibility && !isEnvBrowser()) {
       return `${-750 * zoom.value}px`;
     }
     return '0px';
@@ -31,6 +32,6 @@ export const usePhoneVisibility = () => {
 
   return {
     bottom,
-    visibility: notifVisibility || visibility,
+    visibility: notifVisibility || visibility || isEnvBrowser(),
   };
 };


### PR DESCRIPTION
**Pull Request Description**

If you run the app from `apps/phone` and use `yarn dev` you can develop the app in the browser. 

Currently the phone will never appear on the screen. This is because the `usePhoneVisibility()` hook positions the phone off screen so that when you are in game the phone only shows when its opened. When in the dev/browser mode we want the phone to always show. Added a check for `isEnvBrowser` to know if we are in game vs the browser, and if in browser we do not position the phone off screen. 

Ex: Phone displays correctly in browser
![image](https://github.com/project-error/npwd/assets/18689469/3db9c5e0-1ec4-4149-b7f7-96e0aeac1e40)


**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
