### PR TITLE
Add alternate discord url to the imageSafety config

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -53,6 +53,7 @@
       "discord.com",
       "cdn.discordapp.com",
       "media.discordapp.com",
+      "media.discordapp.net",
       "upload.wikipedia.org",
       "i.projecterror.dev",
       "upcdn.io"


### PR DESCRIPTION
**Pull Request Description**

Added `media.discordapp.net` to the `safeImageUrls`.

When you copy image URL from the camera app for example, the URLs are stored using the media.discordapp.net URL path.
Ex: https://media.discordapp.net/attachments/951758064728559636/1125303590987251742/fivemscreenshot.webp

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
