### PR TITLE
Fix issue where all players hear every notification sound

### DIFF
--- a/apps/game/client/sounds/client-sound.class.ts
+++ b/apps/game/client/sounds/client-sound.class.ts
@@ -12,7 +12,6 @@ export class Sound {
 
   play() {
     PlaySoundFrontend(this._soundId, this._soundName, this._soundSetName, false);
-    PlaySoundFromEntity(this._soundId, this._soundName, PlayerPedId(), this._soundSetName, true, 0);
   }
 
   stop() {


### PR DESCRIPTION
**Pull Request Description**

We found that the `PlaySoundFromEntity` native was causing all clients to hear notification sounds whenever another client received them. For example, if Player1 presses "Preview sound" on the notifications in the Settings app, all players in the server would hear the sound, regardless of their location. 

The intentions behind using `PlaySoundFromEntity` was so that it would apply native GTA 3d spatial audio handling to the sounds so that nearby players would be able to hear when a players phone was ringing or received notifications. 

What we found through much investigation is that the different soundSets in GTA appear to have metadata information attached to each one. This metadata appears to control things like whether or not the sound will make use of the 3d spatial audio or if it will just play to everyone, how loud it is etc. 

The current phone soundSets that are being used do not appear to make use of this 3d spatial audio metadata, so when they are played every client  (within the 400m OneSync culling radius) hears them.

By using just `PlaySoundFrontend`, the player will still be able to hear the notification but only they will be able to hear it. 

In order to have sound played to nearby players a different solution will need to be explored. 


There was a long thread about this in the Discord: https://discord.com/channels/791854454760013827/1113947339342753862


**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
