### PR TITLE
Remove allowNoMessage configuration

### DIFF
--- a/apps/phone/src/apps/twitter/components/AddTweetModal.tsx
+++ b/apps/phone/src/apps/twitter/components/AddTweetModal.tsx
@@ -76,12 +76,19 @@ const AddTweetModal = () => {
     if (message.length > characterLimit) return false;
     if (getNewLineCount(message) < newLineLimit) return true;
   };
+  
+  const isEmptyMessage = () => {
+    const cleanedMessage = clean(message.trim());
+    if ((cleanedMessage && cleanedMessage.length > 0 && isValidMessage(cleanedMessage)) || (images && images.length > 0)){
+      return false;
+    }
+    return true;
+  }
 
   const submitTweet = async () => {
     await promiseTimeout(200);
     const cleanedMessage = clean(message.trim());
-    if ((!cleanedMessage && !allowNoMessage) || (!cleanedMessage && (!images || images.length === 0))) return;
-    if (cleanedMessage.length > 0 && !isValidMessage(cleanedMessage)) return;
+    if (isEmptyMessage()) return;
 
     const data: NewTweet = {
       message: cleanedMessage,

--- a/apps/phone/src/apps/twitter/components/AddTweetModal.tsx
+++ b/apps/phone/src/apps/twitter/components/AddTweetModal.tsx
@@ -70,7 +70,7 @@ const AddTweetModal = () => {
   const handleMessageChange = useCallback((message) => setMessage(message), [setMessage]);
 
   if (!ResourceConfig) return null;
-  const { characterLimit, newLineLimit, allowNoMessage } = ResourceConfig.twitter;
+  const { characterLimit, newLineLimit } = ResourceConfig.twitter;
 
   const isValidMessage = (message) => {
     if (message.length > characterLimit) return false;

--- a/config.default.json
+++ b/config.default.json
@@ -76,7 +76,6 @@
     "enableEmojis": true,
     "enableImages": true,
     "maxImages": 1,
-    "allowNoMessage": false,
     "resultsLimit": 25
   },
   "match": {

--- a/typings/config.ts
+++ b/typings/config.ts
@@ -11,7 +11,6 @@ interface TwitterConfig {
   enableEmojis: boolean;
   enableImages: boolean;
   maxImages: number;
-  allowNoMessage: boolean;
   resultsLimit: number;
 }
 


### PR DESCRIPTION
## Pull Request Description
### Changes
In this pull request:
- Deprecated allowNoMessage configuration
- Change the way to check if the message is empty

#### Current functionality
If configuración is enabled: (Default enabled): Need message and image to send new tweet
If configuration is disabled: Message or Image

#### New functionality
Message or image by default

### Explanation
The option "allowNoMessage" is a configuration that doesn't make sense, I don't see any real use for it if it's ever going to be a "true" or if anyone is going to want it that way.

**Why?** It doesn't make much sense to force someone to have to put a text AND an image and put it in a DEFAULT enabled configuration. Also don't offer FEEDBACK to the user that they are doing something wrong, 80% of people are going to think "oh, it's a bug in the phone". 
When a server administrator says "oh it's a bug in the phone" it will go for 2 options:
1. In administrative case: I'm going to ask for help or try to fix the phone bug. Here he goes to the discord and is told that it is not a bug, but that he lacks eyes to see the configuration.
2. Uninstall the mobile and go to another mobile script.

I wouldn't put my hand in the fire for option 1.... 

**Pull Request Checklist**:
* [X] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [X] Have you built and tested NPWD in-game after the relevant change?
