### PR TITLE
Fix twitter to broadcast deleted tweets to all clients

### DIFF
--- a/apps/game/client/cl_twitter.ts
+++ b/apps/game/client/cl_twitter.ts
@@ -24,3 +24,7 @@ onNet(TwitterEvents.TWEET_LIKED_BROADCAST, (
 ) => {
   sendTwitterMessage(TwitterEvents.TWEET_LIKED_BROADCAST, {tweetId, isAddLike, likedByProfileName});
 });
+
+onNet(TwitterEvents.DELETE_TWEET_BROADCAST, (tweetId: number) => {
+  sendTwitterMessage(TwitterEvents.DELETE_TWEET_BROADCAST, tweetId);
+});

--- a/apps/game/server/twitter/twitter.service.ts
+++ b/apps/game/server/twitter/twitter.service.ts
@@ -199,6 +199,7 @@ class _TwitterService {
       await this.twitterDB.deleteTweet(identifier, reqObj.data.tweetId);
 
       resp({ status: 'ok' });
+      emitNet(TwitterEvents.DELETE_TWEET_BROADCAST, -1, reqObj.data.tweetId);
     } catch (e) {
       twitterLogger.error(`Delete tweet failed, ${e.message}`, {
         source: reqObj.source,

--- a/apps/phone/src/apps/twitter/components/tweet/ShowMore.tsx
+++ b/apps/phone/src/apps/twitter/components/tweet/ShowMore.tsx
@@ -57,7 +57,6 @@ export const ShowMore = ({ id, isReported, isMine }) => {
         });
       }
 
-      deleteTweet(id);
       handleClose();
     });
   };

--- a/apps/phone/src/apps/twitter/hooks/useTwitterService.ts
+++ b/apps/phone/src/apps/twitter/hooks/useTwitterService.ts
@@ -19,7 +19,7 @@ import { useLocation } from 'react-router-dom';
  */
 
 export const useTwitterService = () => {
-  const { addTweet, updateTweetLikes } = useTwitterActions();
+  const { addTweet, updateTweetLikes, deleteTweet } = useTwitterActions();
   const [tweets, setTweets] = useTweetsState();
   const { enqueueNotification } = useNotification();
   const { pathname } = useLocation();
@@ -99,7 +99,12 @@ export const useTwitterService = () => {
     }
   }, [addLikedTweetNotification, updateTweetLikes, tweets]);
 
+  const handleDeleteTweetBroadcast = useCallback((tweetId: number) => {
+    deleteTweet(tweetId);
+  }, [deleteTweet]);
+
   useNuiEvent(APP_TWITTER, TwitterEvents.FETCH_TWEETS_FILTERED, _setFilteredTweets);
   useNuiEvent(APP_TWITTER, TwitterEvents.CREATE_TWEET_BROADCAST, handleTweetBroadcast);
   useNuiEvent(APP_TWITTER, TwitterEvents.TWEET_LIKED_BROADCAST, handleTweetLikedBroadcast);
+  useNuiEvent(APP_TWITTER, TwitterEvents.DELETE_TWEET_BROADCAST, handleDeleteTweetBroadcast);
 };

--- a/typings/twitter.ts
+++ b/typings/twitter.ts
@@ -80,6 +80,7 @@ export enum TwitterEvents {
   CREATE_TWEET = 'npwd:createTweet',
   CREATE_TWEET_BROADCAST = 'createTweetBroadcast',
   DELETE_TWEET = 'npwd:deleteTweet',
+  DELETE_TWEET_BROADCAST = 'npwd:deleteTweetBroadcast',
   TOGGLE_LIKE = 'npwd:toggleLike',
   RETWEET = 'npwd:retweet',
   REPORT = 'npwd:reportTweet',


### PR DESCRIPTION
**Pull Request Description**

**Problem:** If a player deletes a tweet, only that player will see the update in their twitter app, no other clients will receive the delete tweet event and will still be able to see the tweet.

**Fix:** When the player deletes a tweet, we will now broadcast the delete tweet event to all clients so that everyones UI reflects correctly.
- Removed the call of deleteTweet() from ShowMore.tsx, as this was only handling it for the client that did the action and is now unnecessary as the deleteTweetBroadcast event will handle calling this for all clients. 

Example:
https://github.com/project-error/npwd/assets/18689469/ca9b28ba-e2e2-433b-9fa4-efc230fd6dac
- Other player "The Man" deletes his tweets and you can see that they are removed from my UI
- I delete some of my tweets and you can see they are removed from my UI

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
