### PR TITLE
Fix message notification not appearing

### DIFF
--- a/apps/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/apps/phone/src/apps/messages/hooks/useMessageService.ts
@@ -3,12 +3,11 @@ import { Message, MessageConversation, MessageEvents } from '@typings/messages';
 import { useMessageActions } from './useMessageActions';
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
-import { messageState, useActiveMessageConversation } from './state';
+import { useActiveMessageConversation } from './state';
 import { usePhoneVisibility } from '@os/phone/hooks';
 import { useNotification } from '@os/new-notifications/useNotification';
 import { useContactActions } from '@apps/contacts/hooks/useContactActions';
 import useMessages from './useMessages';
-import { useRecoilValue } from 'recoil';
 
 export const useMessagesService = () => {
   const { updateLocalMessages, updateLocalConversations, setMessageReadState } =
@@ -19,19 +18,18 @@ export const useMessagesService = () => {
   const { enqueueNotification } = useNotification();
   const { getDisplayByNumber } = useContactActions();
   const { getMessageConversationById, goToConversation } = useMessages();
-  const activeMessageConversation = useRecoilValue(messageState.activeMessageConversation);
 
   const addNotification = useCallback(
-    (message: string, convoName: string, convoId: number) => {
-      const group = getMessageConversationById(convoId);
+    (message: string, convName: string, convId: number) => {
+      const group = getMessageConversationById(convId);
 
       enqueueNotification({
         appId: 'MESSAGES',
         notisId: 'npwd:messages:messageBroadcast',
         content: message,
         onClick: () => goToConversation(group),
-        secondaryTitle: getDisplayByNumber(convoName) ?? convoName,
-        path: `/messages/conversations/${activeMessageConversation.id}`,
+        secondaryTitle: getDisplayByNumber(convName) ?? convName,
+        path: `/messages/conversations/${convId}`,
       });
     },
     [enqueueNotification],
@@ -44,14 +42,13 @@ export const useMessagesService = () => {
     
     setMessageReadState(conversation_id, 1);
     // Set the current unread count to 1, when they click it will be removed
-    //
     addNotification(message, conversationName, conversation_id);
   };
 
   // This is only called for the receiver of the message. We'll be using the standardized pattern for the transmitter.
   const handleUpdateMessages = useCallback(
     (messageDto: Message) => {
-      if (messageDto.conversation_id !== activeConversation.id) return;
+      if (messageDto.conversation_id !== activeConversation?.id) return;
 
       updateLocalMessages(messageDto);
     },


### PR DESCRIPTION
**Pull Request Description**

**Problem:** If a user receives a text message, but has never opened the message conversation before, they will not receive a notification on their phone.
Fixes issue: https://github.com/project-error/npwd/issues/1017

**Repro steps:**
- PlayerA just logs in and never opens their phone
- PlayerB sends a text msg to PlayerA
- Actual: PlayerA does not receive a notification
- Expected: PlayerA should receive a notification

The reason this is happening is because of the following error. We are trying to read `id` from `activeMessageConversation` which is undefined. 
![image](https://github.com/project-error/npwd/assets/18689469/06bbabb1-73f8-49bf-837a-d9a9ec2515ab)

**Fix:**
Instead of trying to read from `activeMessageConversation` we can use the `convId` that is already passed to the `addNotification` function. This is sufficient as it will always pass the id of the conversation that the msg was for and doesn't have a need to rely on the active conversation. 

Additionally in the `handleUpdateMessages` function, there is a comparison to the `activeConversation.id`, which also throws a `can't read id from undefined` error because `activeConversation` could be undefined. Fixed this error by using optional chaining (`?.`) to make sure the variable is defined before trying to access variables from it.


Demo:
https://github.com/project-error/npwd/assets/18689469/bf6751ff-c222-4304-a21d-7fb685e6aba8
- Shows a fresh restart of the phone
- PlayerA never opens their phone
- PlayerB send a msg to PlayerA
- PlayerA receives the notification

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
