### PR TITLE
Delete photo file after upload succeeds

### DIFF
--- a/apps/game/server/photo/photo.service.ts
+++ b/apps/game/server/photo/photo.service.ts
@@ -73,6 +73,9 @@ class _PhotoService {
               const identifier = PlayerService.getIdentifier(reqObj.source);
               const photo = await this.photoDB.uploadPhoto(identifier, res);
 
+              // File is uploaded, so its safe to remove
+              fs.rmSync(filePath);
+
               return resp({ status: 'ok', data: photo });
             } catch (err) {
               photoLogger.error(`Failed to upload photo`, {


### PR DESCRIPTION
**Pull Request Description**

Problem: If the user has the config `useWebhook: true`, picture files are created in the `uploads/` folder but are never cleaned up / deleted after the upload succeeds, thus the files continue to build up on the machine. 

Repro: 
- set useWebhook: true and set discord webhook to upload to
- take a picture in game with camera app
- look at the `uploads/` folder and you will see that the file created for the photo still exists
- expected: after successful upload the file should be deleted

There is already a file cleanup called below for the codepath when useWebhook is false. The fix was to add the same file path cleanup inside the useWebhook flow.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
