### PR TITLE
Fix @typings import for onMessage

### DIFF
--- a/apps/game/server/messages/middleware/onMessage.ts
+++ b/apps/game/server/messages/middleware/onMessage.ts
@@ -1,4 +1,4 @@
-import { OnMessageExportCtx } from '../../../../typings/messages';
+import { OnMessageExportCtx } from '@typings/messages';
 
 const exp = global.exports;
 


### PR DESCRIPTION
**Pull Request Description**

The relative path import in onMessage.ts is off. It technically needs to go up one more level `'../../../../../typings/messages';`. We can also just use the package import `@typings/messages`. 

Before import not found:
![image](https://github.com/project-error/npwd/assets/18689469/44902b48-3dd9-4519-a731-8d8666c551f7)
After import found:
![image](https://github.com/project-error/npwd/assets/18689469/e1958690-0b3b-4b5a-973c-ecb9e3555805)


**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
