### PR TITLE
fix(game/sounds): release sound ids

### DIFF
--- a/apps/game/client/sounds/client-sound.class.ts
+++ b/apps/game/client/sounds/client-sound.class.ts
@@ -1,3 +1,4 @@
+const SoundIdsByName: { [k: string]: number } = {};
 export class Sound {
   private readonly _soundName: string;
   private readonly _soundSetName: string;
@@ -7,15 +8,22 @@ export class Sound {
     this._soundName = soundName;
     this._soundSetName = soundSetName;
 
+    if (SoundIdsByName[this._soundName]) {
+      ReleaseSoundId(SoundIdsByName[this._soundName]);
+      delete SoundIdsByName[this._soundName];
+    }
+
     this._soundId = GetSoundId();
+    SoundIdsByName[this._soundName] = this._soundId;
   }
 
   play() {
     PlaySoundFrontend(this._soundId, this._soundName, this._soundSetName, false);
-    PlaySoundFromEntity(this._soundId, this._soundName, PlayerPedId(), this._soundSetName, true, 0);
   }
 
   stop() {
     StopSound(this._soundId);
+    ReleaseSoundId(this._soundId);
+    if (SoundIdsByName[this._soundName]) delete SoundIdsByName[this._soundName];
   }
 }


### PR DESCRIPTION
**Pull Request Description**

## Bug
FiveM has a limit of about 100 active soundIDs, if you don't correctly release a soundID you end up with a -1 ID which ends up muting any native sounds, even native sounds outside the scope of this resource(e.g. police sirens).

### Solution
Correctly release sounds IDs after use or before creating a new one.

I've also included the same fix from #1027

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
