### PR TITLE
fix:(bridge/ndcore): exports & resource name

### DIFF
--- a/apps/game/server/bridge/ndcore/ndcore-server.ts
+++ b/apps/game/server/bridge/ndcore/ndcore-server.ts
@@ -66,7 +66,7 @@ export class NDCoreFramework implements Strategy {
 
   onStart(): void {
     on('onServerResourceStart', async (resource: string) => {
-      const NDCore = global.exports['ND-Core'].GetCoreObject();
+      const NDCore = global.exports['ND_Core'];
 
       if (resource === GetCurrentResourceName()) {
         const onlinePlayers = NDCore.getPlayers() as NDPlayer[];


### PR DESCRIPTION
**Pull Request Description**
The getcoreobject function is no longer a thing in nd v2 and the resource name is "ND_Core" not "ND-Core".

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [ ] Have you built and tested NPWD in-game after the relevant change?
