### PR TITLE
Fixed an explicit SQL error about dark_chat tables

### DIFF
--- a/import.sql
+++ b/import.sql
@@ -202,7 +202,7 @@ CREATE TABLE IF NOT EXISTS `npwd_phone_gallery`
 
 CREATE TABLE `npwd_darkchat_channels` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`channel_identifier` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
+	`channel_identifier` VARCHAR(191) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`label` VARCHAR(255) NULL DEFAULT '' COLLATE 'utf8mb4_general_ci',
 	PRIMARY KEY (`id`) USING BTREE,
 	UNIQUE INDEX `darkchat_channels_channel_identifier_uindex` (`channel_identifier`) USING BTREE


### PR DESCRIPTION
Fixed an explicit SQL error that caused the UNIQUE INDEX to be too long when creating a dark chat related table.

According to the MySQL INNODB limit, when using the utf8mb4 character set, you cannot set a UNIQUE INDEX longer than 191 characters. On line 208 of import.sql, the community developer misidentifies the 255 character column defined on line 205 as the index. This caused MySql to fail to execute the statement, which in turn caused the last three data tables to fail to be created. A workaround for reference is to "change" VARCHAR(255) to "VARCHAR(191)" in line 205, but you can also set 191 to any number less than it you like.

Reference: https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html