### PR TITLE
fix(phone\common\hooks): correctly handle already loaded apps

### DIFF
--- a/apps/phone/src/common/hooks/useExternalApps.tsx
+++ b/apps/phone/src/common/hooks/useExternalApps.tsx
@@ -88,18 +88,14 @@ const useExternalAppsAction = () => {
   }, []);
 
   const getConfigs = useCallback(
-    async (externalApps: string[], existingApps: any[]) => {
+    async (externalApps: string[], existingApps: IApp[]) => {
       const appAlreadyLoaded = (appName: string) => {
-        return existingApps.some((app) => app.id === appName);
+        return existingApps.find((app) => app.id === appName);
       };
 
       const configs = await Promise.all(
         externalApps.map(async (appName) => {
-          if (appAlreadyLoaded(appName)) return null;
-
-          const app = await generateAppConfig(appName);
-          if (!app) return null;
-          return app;
+          return appAlreadyLoaded(appName) ?? await generateAppConfig(appName);
         }),
       );
 


### PR DESCRIPTION
**Pull Request Description**

 - When having multiple external apps loaded, existing apps would vanish due to `appAlreadyLoaded` returning null and not the existing app config
 
 **Changes**
 - Used nullish coalescence to determine if we require invoking `generateAppConfig`
 - Remove unnecessary conditionals
 - Updated `existingApps` type

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [x] Have you built and tested NPWD in-game after the relevant change?
