### PR TITLE
Enabling notifications for external apps

### DIFF
--- a/apps/phone/src/common/hooks/useExternalApps.tsx
+++ b/apps/phone/src/common/hooks/useExternalApps.tsx
@@ -19,7 +19,7 @@ const useExternalAppsAction = () => {
       const element = document.createElement('script');
 
       element.src = url;
-      element.type = 'text/javascript';
+      element.type = 'module';
       element.async = true;
 
       document.head.appendChild(element);
@@ -95,7 +95,7 @@ const useExternalAppsAction = () => {
 
       const configs = await Promise.all(
         externalApps.map(async (appName) => {
-          return appAlreadyLoaded(appName) ?? await generateAppConfig(appName);
+          return appAlreadyLoaded(appName) ?? (await generateAppConfig(appName));
         }),
       );
 

--- a/apps/phone/src/os/apps/hooks/useApps.tsx
+++ b/apps/phone/src/os/apps/hooks/useApps.tsx
@@ -6,11 +6,14 @@ import { SvgIconComponent } from '@mui/icons-material';
 import { useTheme } from '@mui/material';
 import { useSettingsValue } from '../../../apps/settings/hooks/useSettings';
 import { IconSetObject } from '@typings/settings';
+import { useRecoilValue } from 'recoil';
+import { phoneState } from '@os/phone/hooks/state';
 
 export const useApps = () => {
   const { icons } = useNotifications();
   const theme = useTheme();
   const curIconSet = useSettingsValue().iconSet.value as IconSetObject;
+  const externalApps = useRecoilValue(phoneState.extApps);
 
   const apps: IApp[] = useMemo(() => {
     return APPS.map((app) => {
@@ -52,7 +55,10 @@ export const useApps = () => {
     });
   }, [icons, curIconSet, theme]);
 
-  const allApps = useMemo(() => [...apps], [apps]);
+  const allApps = useMemo(
+    () => [...apps, ...externalApps.filter((app) => app)],
+    [apps, externalApps],
+  );
   const getApp = useCallback(
     (id: string): IApp => {
       return allApps.find((a) => a.id === id) || null;

--- a/apps/phone/src/os/new-notifications/components/NotificationBase.tsx
+++ b/apps/phone/src/os/new-notifications/components/NotificationBase.tsx
@@ -38,8 +38,6 @@ const NotificationBase = forwardRef<HTMLDivElement, NotificationBaseProps>((prop
         console.warn('App does not have a notification icon');
     }
 
-    console.log("app bg", app.backgroundColor)
-
     return (
         <SnackbarContent
             onClick={handleNotisClick}


### PR DESCRIPTION
**Pull Request Description**

Fixed two issues preventing external apps from creating notifications:

1. Module Loading
   - Changed script element type from 'text/javascript' to 'module' in useExternalApps.tsx
   - Allows proper loading of ES6 module-based external apps (remoteEntry.js)
   - Resolves "Cannot use import statement outside a module" error

2. App Registry Integration
   - Added external apps from phoneState.extApps to useApps hook
   - Enables notification system to find external apps via getApp() function
   - Fixes "The app with id {appId} was not found" error
 
3. Removed debug console.log for app background color
   - This was causing unwanted console output during notification rendering
   
Changes:
- apps/phone/src/common/hooks/useExternalApps.tsx: Set script type to 'module'
- apps/phone/src/os/apps/hooks/useApps.tsx: Include external apps in allApps array
- apps/phone/src/os/new-notifications/components/NotificationBase.tsx: removed debug console log

This ensures external apps like npwd_qbx_garages can successfully create
notifications through the NPWD notification system.

**Pull Request Checklist**:
* [Yes ] Have you followed the guidelines in our Contributing document and Code of Conduct?
* [Yes ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/project-error/npwd/pulls) for the same update/change?
* [Yes ] Have you built and tested NPWD in-game after the relevant change?
